### PR TITLE
8.0.1.5

### DIFF
--- a/CT_BottomBar/CT_BottomBar.lua
+++ b/CT_BottomBar/CT_BottomBar.lua
@@ -689,6 +689,7 @@ module.update = function(self, optName, value)
 		module:loadAddon("Vehicle Bar");
 		module:loadAddon("Status Bar");
 		module:loadAddon("Framerate Bar");
+		module:loadAddon("Talking Head");
 	end
 
 	-- Hook some functions.

--- a/CT_BottomBar/CT_BottomBar.toc
+++ b/CT_BottomBar/CT_BottomBar.toc
@@ -1,5 +1,5 @@
 ## Interface: 80000
-## Version: 8.0.1.4
+## Version: 8.0.1.5
 ## Title: CT_BottomBar
 ## Notes: Breaks up the main menu bar into movable pieces.
 ## DefaultState: Enabled
@@ -26,3 +26,4 @@ CT_BottomBar_Possess.lua
 CT_BottomBar_Vehicle.lua
 CT_BottomBar_StatusBar.lua
 CT_BottomBar_FPS.lua
+CT_BottomBar_TalkingHead.lua

--- a/CT_BottomBar/CT_BottomBar_Addons.lua
+++ b/CT_BottomBar/CT_BottomBar_Addons.lua
@@ -29,22 +29,22 @@ local addonFrameTable;
 local function addonFrame_OnEnter(self)
 	local object = self.object;
 
-	if (not appliedOptions.dragHideTooltip) then
-		-- Show addon name and drag instructions.
-		local text = "|c00FFFFFF" .. object.addonName .. "|r\n" .. "Left click to drag";
+	-- REMOVED CONDITIONAL IN 8.0.1.5 -- if (not appliedOptions.dragHideTooltip) then
+	-- Show addon name and drag instructions.
+	local text = "|c00FFFFFF" .. object.addonName .. "|r\n" .. "Left click to drag";
 
-		-- If this frame is capable of rotation...
-		if (object.rotateFunc) then
-			-- Show rotation instructions.
-			text = text .. "\nRight click to rotate";
-		end
-
-		-- Show reset instructions.
-		text = text .. "\nShift click to reset";
-
-		-- Show the tooltip.
-		module:displayTooltip(self, text);
+	-- If this frame is capable of rotation...
+	if (object.rotateFunc) then
+		-- Show rotation instructions.
+		text = text .. "\nRight click to rotate";
 	end
+
+	-- Show reset instructions.
+	text = text .. "\nShift click to reset";
+
+	-- Show the tooltip.
+	module:displayTooltip(self, text);
+	-- REMOVED CONDITIONAL IN 8.0.1.5 -- end
 end
 
 local function addonFrame_OnLeave(self)

--- a/CT_BottomBar/CT_BottomBar_Arrows.lua
+++ b/CT_BottomBar/CT_BottomBar_Arrows.lua
@@ -19,13 +19,7 @@ local module = _G.CT_BottomBar;
 local ctRelativeFrame = module.ctRelativeFrame;
 local appliedOptions;
 
-local CT_BottomBar_Arrows_MainMenuBarArtFrameDefaultPosition = nil;
-local CT_BB_Arrows_MainMenuArtDefaultPoint = nil;
-local CT_BB_Arrows_MainMenuArtDefaultRelativeTo = nil;
-local CT_BB_Arrows_MainMenuArtDefaultRelativePoint = nil;
-local CT_BB_Arrows_MainMenuArtDefaultX = nil;
-local CT_BB_Arrows_MainMenuArtDefaultY = nil;
-local CT_BB_Arrows_isEnabled = nil;
+local CT_BB_PageNumber;
 
 --------------------------------------------
 -- Action bar arrows and page number
@@ -37,7 +31,6 @@ local function addon_Update(self)
 	local objUp = ActionBarUpButton;
 	local objDown = ActionBarDownButton;
 
-
 	self.helperFrame:ClearAllPoints();
 	self.helperFrame:SetPoint("TOPLEFT", objUp, "TOPLEFT", -5, 5);
 	self.helperFrame:SetPoint("BOTTOMRIGHT", objDown, "BOTTOMRIGHT", 15, -5);
@@ -48,33 +41,31 @@ local function addon_Update(self)
 	objDown:ClearAllPoints();
 	objUp:ClearAllPoints();
 
-	objDown:SetPoint("BOTTOMLEFT", self.frame, 0, 0);
+	objDown:SetPoint("TOPRIGHT", self.frame, 0, 0);
 	objUp:SetPoint("BOTTOMLEFT", objDown, "TOPLEFT", 0, 0);
-	
-	--From WoW 8.0 forward, this moves the number next to the arrows but ONLY if the background textures are hidden
-	CT_BottomBar_Arrows_FixMainMenuBarArtFrameBackground(self)
-
-	
-end
-
-function CT_BottomBar_Arrows_FixMainMenuBarArtFrameBackground(self)
-	if (appliedOptions.hideTexturesBackground and CT_BB_Arrows_isEnabled) then
-		MainMenuBarArtFrameBackground:ClearAllPoints();
-		MainMenuBarArtFrameBackground:SetPoint("BOTTOMLEFT", self.frame, "BOTTOMLEFT", -512, 0);
-	else
-		MainMenuBarArtFrameBackground:ClearAllPoints();
-		MainMenuBarArtFrameBackground:SetPoint(CT_BB_Arrows_MainMenuArtDefaultPoint, CT_BB_Arrows_MainMenuArtDefaultRelativeTo, CT_BB_Arrows_MainMenuArtDefaultRelativePoint, CT_BB_Arrows_MainMenuArtDefaultX, CT_BB_Arrows_MainMenuArtDefaultY);
-	end
 end
 
 local function addon_Enable(self)
-	CT_BB_Arrows_isEnabled = true;
 	self.frame:SetClampRectInsets(10, -10, 39, 10);
+	MainMenuBarArtFrame.PageNumber:Hide();
+	if (CT_BB_PageNumber) then
+		CT_BB_PageNumber:Show();
+	else
+		CT_BB_PageNumber = self.frame:CreateFontString(nil,"OVERLAY","GameFontNormalSmall");
+		CT_BB_PageNumber:SetText(GetActionBarPage());
+		CT_BB_PageNumber:SetPoint("LEFT",self.frame,"RIGHT", 5, 0);
+		self.frame:RegisterEvent("ACTIONBAR_PAGE_CHANGED");
+		self.frame:SetScript("OnEvent",function(newself, event, ...)
+			if (event == "ACTIONBAR_PAGE_CHANGED") then
+				CT_BB_PageNumber:SetText(GetActionBarPage());
+			end
+		end);
+	end
 end
 
 local function addon_Disable(self)
-	CT_BB_Arrows_isEnabled = false;
-	CT_BottomBar_Arrows_FixMainMenuBarArtFrameBackground(self)
+	MainMenuBarArtFrame.PageNumber:Show();
+	CT_BB_PageNumber:Hide();
 end
 
 local function addon_Init(self)
@@ -89,8 +80,6 @@ local function addon_Init(self)
 
 	local frame = CreateFrame("Frame", "CT_BottomBar_" .. self.frameName .. "_GuideFrame");
 	self.helperFrame = frame;
-	
-	CT_BB_Arrows_MainMenuArtDefaultPoint, CT_BB_Arrows_MainMenuArtDefaultRelativeTo, CT_BB_Arrows_MainMenuArtDefaultRelativePoint, CT_BB_Arrows_MainMenuArtDefaultX, CT_BB_Arrows_MainMenuArtDefaultY = MainMenuBarArtFrameBackground:GetPoint(1);
 
 	return true;
 end
@@ -115,8 +104,7 @@ local function addon_Register()
 		addon_Disable,  -- no disable function
 		"helperFrame",
 		ActionBarUpButton,
-		ActionBarDownButton,
-		MainMenuBarArtFrame.PageNumber
+		ActionBarDownButton
 	);
 end
 

--- a/CT_BottomBar/CT_BottomBar_MainMenu.lua
+++ b/CT_BottomBar/CT_BottomBar_MainMenu.lua
@@ -81,20 +81,6 @@ function module:toggleGryphons(hide)
 		MainMenuBarArtFrame.LeftEndCap:Show();
 		MainMenuBarArtFrame.RightEndCap:Show();
 	end
-	if (type(module.frame) == "table") then
-		-- Change the checkbox in CT_BottomBar
-		local cb = module.frame.general.hideGryphons;
-		cb:SetChecked(hide);
-	end
-	if (CT_Core) then
-		local opt = "hideGryphons";
-		if (CT_Core:getOption(opt) ~= hide) then
-			-- Change the same option in CT_Core
-			gryphonLoop = true;
-			CT_Core:setOption(opt, hide, true);
-			gryphonLoop = nil;
-		end
-	end
 end
 
 --------------------------------------------
@@ -140,9 +126,6 @@ function module:hideTexturesBackground(hide)
 		MainMenuBarArtFrameBackground:Show();
 		hidMainBackground = false;
 	end
-	
-	-- From WoW 8.0.1 foward, it is necessary for this frame to follow the arrows when it is hidden, but stay in place when visible
-	CT_BottomBar_Arrows_FixMainMenuBarArtFrameBackground(module.ctActionBarPage);
 	
 end
 

--- a/CT_BottomBar/CT_BottomBar_Menu.lua
+++ b/CT_BottomBar/CT_BottomBar_Menu.lua
@@ -21,7 +21,6 @@
 -- AchievementMicroButton
 -- QuestLogMicroButton
 -- GuildMicroButton
--- PVPMicroButton
 -- LFDMicroButton
 -- CollectionsMicroButton
 -- EJMicroButton
@@ -91,9 +90,7 @@ local function addon_UpdateOrientation_OurUI(self, orientation)
 		if (orientation == "ACROSS") then
 			setpoint(obj, "LEFT", frames[i-1], "RIGHT", -3, 0);
 		else
-			-- Using a large Y value (23) since the buttons look shorter than they are.
-			-- See also the talent and achievement hooked functions for the same Y value.
-			setpoint(obj, "TOP", frames[i-1], "BOTTOM", 0, 23);
+			setpoint(obj, "TOP", frames[i-1], "BOTTOM", 0, 1);
 		end
 	end
 
@@ -107,11 +104,11 @@ local function addon_Update_OurUI(self)
 
 	-- Anchor the left and right most buttons to our helper frame.
 	local objChar = CharacterMicroButton;  -- Left most button
-	local objHelp = HelpMicroButton;  -- Right most button
+	local objHelp = MainMenuMicroButton;  -- Right most button
 	local frame = self.helperFrame;
 	frame:ClearAllPoints();
-	frame:SetPoint("TOPLEFT", objChar, 0, -20);
-	frame:SetPoint("BOTTOMRIGHT", objHelp);
+	frame:SetPoint("TOPLEFT", objChar, "TOPLEFT", -3, 3);
+	frame:SetPoint("BOTTOMRIGHT", objHelp, "BOTTOMRIGHT", 3, -3);
 
 	-- Orient for our UI.
 	addon_UpdateOrientation_OurUI(self, self.orientation);
@@ -144,7 +141,7 @@ local function addon_Update_OverrideUI(self)
 	local anchorX, anchorY = addon_OverrideActionBar_GetMicroButtonAnchor();
 
 	local obj1 = frames[2];  -- CharacterMicroButton
-	local obj2 = frames[8];  -- PVPMicroButton
+	local obj2 = frames[8];  -- LFDMicroButton
 
 	obj1:ClearAllPoints();
 	setpoint(obj1, "BOTTOMLEFT", bar, "BOTTOMLEFT", anchorX, anchorY);
@@ -189,7 +186,7 @@ local function addon_Update_PetBattleUI(self)
 	local anchorX, anchorY = -9, 25;
 
 	local obj1 = frames[2];  -- CharacterMicroButton
-	local obj2 = frames[8];  -- PVPMicroButton
+	local obj2 = frames[8];  -- LFDMicroButton
 
 	obj1:ClearAllPoints();
 	setpoint(obj1, "BOTTOMLEFT", bar, "BOTTOMLEFT", anchorX, anchorY);
@@ -452,14 +449,14 @@ local function addon_Register()
 		TalentMicroButton, -- 4
 		AchievementMicroButton, -- 5
 		QuestLogMicroButton, -- 6
-		GuildMicroButton, -- 7
-		--PVPMicroButton, -- 8
-		LFDMicroButton, -- 9
-		CollectionsMicroButton, -- 10
-		EJMicroButton, -- 11
-		StoreMicroButton, -- 12
-		MainMenuMicroButton -- 13
-		--HelpMicroButton -- 14
+		GuildMicroButton, -- 7	
+		LFDMicroButton, -- 8
+		CollectionsMicroButton, -- 9
+		EJMicroButton, -- 10
+		StoreMicroButton, -- 11
+		MainMenuMicroButton -- 12
+		--PVPMicroButton, -- old 8
+		--HelpMicroButton -- old 14
 	);
 end
 

--- a/CT_BottomBar/CT_BottomBar_Options.lua
+++ b/CT_BottomBar/CT_BottomBar_Options.lua
@@ -327,7 +327,7 @@ function module:updateOption(optName, value)
 		end
 		
 		
-
+--[[ REMOVED IN 8.0.1.5
 	elseif (optName == "repBarHideNoRep" or
 		optName == "repBarCoverExpBar" or
 		optName == "expBarShowMaxLevelBar"
@@ -427,6 +427,8 @@ function module:updateOption(optName, value)
 			ReputationWatchBar_Update();
 		end
 
+END REMOVED IN 8.0.1.5 --]]
+
 	elseif (optName == "hideGryphons") then
 		value = value ~= false;
 		if (applyUnprotectedOption(optName, value)) then
@@ -461,12 +463,12 @@ function module:updateOption(optName, value)
 			end
 		end
 
-	elseif (optName == "dragHideTooltip") then
-		value = not not value;
-		applyUnprotectedOption(optName, value);
+	-- REMOVED IN 8.0.1.5 -- elseif (optName == "dragHideTooltip") then
+	-- REMOVED IN 8.0.1.5 -- 	value = not not value;
+	-- REMOVED IN 8.0.1.5 -- 	applyUnprotectedOption(optName, value);
 
 	elseif (optName == "clampFrames") then
-		value = not not value;
+		value = value ~= false;  -- change in 8.0.1.5 to default as true
 		if (applyUnprotectedOption(optName, value)) then
 			for key, obj in ipairs(module.addons) do
 				if (not obj.isDisabled) then
@@ -624,54 +626,17 @@ module.frame = function()
 
 	-- Tips
 	optionsBeginFrame(-5, 0, "frame#tl:0:%y#r");
-		optionsAddObject(  0,   17, "font#tl:5:%y#v:GameFontNormalLarge#Tips");
 		optionsAddObject( -5, 3*14, "font#t:0:%y#s:0:%s#l:13:0#r#You can use /ctbb, /ctbottom, or /ctbottombar to open this options window directly.#" .. textColor2 .. ":l");
-		optionsAddObject( -5, 2*14, "font#t:0:%y#s:0:%s#l:13:0#r#Bars are only movable when this options window is open.#" .. textColor2 .. ":l");
-		optionsAddObject( -5, 2*14, "font#t:0:%y#s:0:%s#l:13:0#r#Some options if changed will only be applied when you are not in combat.#" .. textColor2 .. ":l");
-	optionsEndFrame();
-
-	-- Options window
-	optionsBeginFrame(-20, 0, "frame#tl:0:%y#br:tr:0:%b");
-		optionsAddObject(  0,   17, "font#tl:5:%y#v:GameFontNormalLarge#Options window");
-		optionsAddObject( -5,   26, "checkbutton#tl:20:%y#o:dragHideTooltip#Hide drag frame tooltips");
-		optionsAddObject(  6,   26, "checkbutton#tl:20:%y#o:clampFrames#Cannot drag bars completely off screen");
-		if (CT_BarMod) then
-			optionsAddObject( -5,   26, "checkbutton#tl:20:%y#i:showCTBarMod#o:showCTBarMod#Show drag frames for CT_BarMod bars");
-		end
-	optionsEndFrame();
-
-	-- Artwork Options
-	optionsBeginFrame(-20, 0, "frame#tl:0:%y#br:tr:0:%b#i:general");
-		optionsAddObject(  0,   17, "font#tl:5:%y#v:GameFontNormalLarge#Artwork");
-
-		optionsAddObject( -5,   26, "checkbutton#tl:20:%y#i:showLions#o:showLions#Show lions instead of gryphons");
-		optionsAddObject(  6,   26, "checkbutton#tl:20:%y#i:hideGryphons#o:hideGryphons:true#Hide the gryphons/lions");
-		optionsAddObject(  6,   26, "checkbutton#tl:20:%y#i:hideTexturesBackground#o:hideTexturesBackground:true#Hide the background textures");
-		optionsAddObject(  6,   26, "checkbutton#tl:20:%y#i:hideMenuAndBagsBackground#o:hideMenuAndBagsBackground:true#Hide the menu and bags textures");
-	optionsEndFrame();
-
-	-- Override Frame
-	optionsBeginFrame(-20, 0, "frame#tl:0:%y#br:tr:0:%b");
-		optionsAddObject(  0,   17, "font#tl:5:%y#v:GameFontNormalLarge#Override/Vehicle Frame");
-		optionsAddObject( -5, 4*14, "font#t:0:%y#s:0:%s#l:20:0#r#This is a large frame used for vehicle and override bars. If you hide the frame you will need to use an alternate bar that can show vehicle and override buttons.#" .. textColor2 .. ":l");
-		optionsAddObject( -5,   26, "checkbutton#tl:20:%y#o:vehicleHideFrame#Hide the override/vehicle frame.");
-		optionsAddObject(  6,   26, "checkbutton#tl:20:%y#o:vehicleHideEnabledBars:true#Hide the activated CT_BottomBar bars.");
-	optionsEndFrame();
-
-	-- Pet Battle Frame
-	optionsBeginFrame(-20, 0, "frame#tl:0:%y#br:tr:0:%b");
-		optionsAddObject(  0,   17, "font#tl:5:%y#v:GameFontNormalLarge#Pet Battle Frame");
-		optionsAddObject( -5,   26, "checkbutton#tl:20:%y#o:petbattleHideEnabledBars:true#Hide the activated CT_BottomBar bars.");
+		optionsAddObject( -5, 2*14, "font#t:0:%y#s:0:%s#l:13:0#r#Remember to scroll down!  There are lots of customizations down below.#" .. textColor2 .. ":l");
 	optionsEndFrame();
 
 	-- Bars
 	optionsBeginFrame(-20, 0, "frame#tl:0:%y#br:tr:0:%b#i:bar");
 		optionsAddObject(  0,    1, "texture#tl:5:%y#br:tr:0:%b#1:1:1");
-		optionsAddObject(-15,   17, "font#tl:5:%y#v:GameFontNormalLarge#Bars");
+		optionsAddObject(-15,   17, "font#tl:5:%y#v:GameFontNormalLarge#Movable Bars");
 
-		optionsAddObject(-10, 3*14, "font#t:0:%y#s:0:%s#l:15:0#r#An activated bar can be moved, hidden, and possibly rotated. Some other options may also be available depending on the bar.#" .. textColor2 .. ":l");
-		optionsAddObject( -5, 3*14, "font#t:0:%y#s:0:%s#l:15:0#r#When you deactivate a bar, an attempt will be made to restore the bar to its default state if applicable.#" .. textColor2 .. ":l");
-		optionsAddObject( -5, 3*14, "font#t:0:%y#s:0:%s#l:15:0#r#If a bar does not deactivate as expected, restart your addons once using the /reload command.#" .. textColor2 .. ":l");
+		optionsAddObject(-10, 3*14, "font#t:0:%y#s:0:%s#l:15:0#r#Activate a bar to control it with this addon.  Deactivate it to restore the original condition.#" .. textColor2 .. ":l");
+		optionsAddObject( -5, 3*14, "font#t:0:%y#s:0:%s#l:15:0#r#If a bar does not deactivate as expected, try\n/console reloadui#" .. textColor2 .. ":l");
 
 		do
 			local off = -15;
@@ -717,11 +682,53 @@ module.frame = function()
 				updateBarWidgets();
 			end
 		);
+		
+		optionsAddObject(  -15,    1, "texture#tl:5:%y#br:tr:0:%b#1:1:1");
+		
+	optionsEndFrame();
+
+	-- General Options
+	optionsBeginFrame(-20, 0, "frame#tl:0:%y#br:tr:0:%b");
+		optionsAddObject(  0,   17, "font#tl:5:%y#v:GameFontNormalLarge#Important General Options");
+		optionsAddObject(-20,   17, "font#tl:5:%y#v:GameFontNormal#Background Textures");
+		optionsAddObject( -5, 2*14, "font#t:0:%y#s:0:%s#l:13:0#r#Control the grey backgrounds behind the default UI bar positions.#" .. textColor2 .. ":l");
+		optionsAddObject( -5,   26, "checkbutton#tl:20:%y#i:showLions#o:showLions#Show lions instead of gryphons");
+		optionsAddObject(  6,   26, "checkbutton#tl:20:%y#i:hideGryphons#o:hideGryphons:true#Hide the gryphons/lions");
+		optionsAddObject(  6,   26, "checkbutton#tl:20:%y#i:hideTexturesBackground#o:hideTexturesBackground:true#Hide the background textures");
+		--optionsAddObject( -5, 2*14, "font#t:0:%y#s:0:%s#l:13:0#r#Warning: don't hide the bag/menu background if you unchecked 'Activate' up above#" .. textColor2 .. ":l");
+		optionsAddObject(  6,   26, "checkbutton#tl:20:%y#i:hideMenuAndBagsBackground#o:hideMenuAndBagsBackground:true#Hide the menu and bags textures");
+		optionsAddObject(-20,   17, "font#tl:5:%y#v:GameFontNormal#How to move bars");
+		optionsAddObject( -5, 2*14, "font#t:0:%y#s:0:%s#l:13:0#r#You can move a bar off the screen if you want... but consider just hiding it instead#" .. textColor2 .. ":l");
+		optionsAddObject(  -5,   26, "checkbutton#tl:20:%y#o:clampFrames:true#Cannot drag bars completely off screen");
+		if (CT_BarMod) then
+			optionsAddObject( -5, 2*14, "font#t:0:%y#s:0:%s#l:13:0#r#The numbered bars are part of CT_BarMod.\nCheck this to move them at the same time.#" .. textColor2 .. ":l");
+			optionsAddObject( -5,   26, "checkbutton#tl:20:%y#i:showCTBarMod#o:showCTBarMod#Move CT_BarMod bars at the same time");
+		end
+		optionsAddObject(  -15,    1, "texture#tl:5:%y#br:tr:0:%b#1:1:1");
+	optionsEndFrame();
+	
+	-- Bar-Specific Options
+	optionsBeginFrame(-20, 0, "frame#tl:0:%y#br:tr:0:%b");
+		optionsAddObject(  0,   17, "font#tl:5:%y#v:GameFontNormalLarge#Bar-Specific Options");
+	optionsEndFrame();
+	
+	-- Override Frame
+	optionsBeginFrame(-20, 0, "frame#tl:0:%y#br:tr:0:%b");
+		optionsAddObject(  0,   17, "font#tl:5:%y#v:GameFontNormal#Override/Vehicle Frame");
+		optionsAddObject( -5, 4*14, "font#t:0:%y#s:0:%s#l:20:0#r#This is a large frame used for vehicle and override bars. If you hide the frame you will need to use an alternate bar that can show vehicle and override buttons.#" .. textColor2 .. ":l");
+		optionsAddObject( -5,   26, "checkbutton#tl:20:%y#o:vehicleHideFrame#Hide the override/vehicle frame.");
+		optionsAddObject(  6,   26, "checkbutton#tl:20:%y#o:vehicleHideEnabledBars:true#Hide the activated CT_BottomBar bars.");
+	optionsEndFrame();
+
+	-- Pet Battle Frame
+	optionsBeginFrame(-20, 0, "frame#tl:0:%y#br:tr:0:%b");
+		optionsAddObject(  0,   17, "font#tl:5:%y#v:GameFontNormal#Pet Battle Frame");
+		optionsAddObject( -5,   26, "checkbutton#tl:20:%y#o:petbattleHideEnabledBars:true#Hide the activated CT_BottomBar bars.");
 	optionsEndFrame();
 
 	-- Action bar options
 	optionsBeginFrame(-20, 0, "frame#tl:0:%y#br:tr:0:%b#i:actionbar");
-		optionsAddObject(  0,   17, "font#tl:5:%y#v:GameFontNormalLarge#Action Bar");
+		optionsAddObject(  0,   17, "font#tl:5:%y#v:GameFontNormal#Action Bar");
 
 		optionsAddObject( -5, 2*14, "font#t:0:%y#s:0:%s#l:20:0#r#CT_BottomBar does not include support for manipulating the default main action bar.#" .. textColor2 .. ":l");
 		optionsAddObject( -5, 2*14, "font#t:0:%y#s:0:%s#l:20:0#r#The main action bar can either be used in its default state or it can be disabled.#" .. textColor2 .. ":l");
@@ -742,7 +749,7 @@ module.frame = function()
 	-- Bags Bar
 	if (module.ctBagsBar) then
 		optionsBeginFrame(-20, 0, "frame#tl:0:%y#br:tr:0:%b");
-			optionsAddObject(  0,   17, "font#tl:5:%y#v:GameFontNormalLarge#Bags Bar");
+			optionsAddObject(  0,   17, "font#tl:5:%y#v:GameFontNormal#Bags Bar");
 
 			optionsAddObject( -5, 2*14, "font#t:0:%y#s:0:%s#l:20:0#r#These options will have no effect if the Bags Bar is not activated.#" .. textColor3 .. ":l");
 
@@ -755,7 +762,7 @@ module.frame = function()
 	-- Experience & Reputation Status Bar
 	if (module.ctStatusBar) then
 		optionsBeginFrame(-25, 0, "frame#tl:0:%y#br:tr:0:%b#i:status#r");
-			optionsAddObject(  0,   17, "font#tl:5:%y#v:GameFontNormalLarge#Exp/Rep/Power Status Bars");
+			optionsAddObject(  0,   17, "font#tl:5:%y#v:GameFontNormal#Exp/Rep/Power Status Bars");
 
 			optionsAddObject( -5, 2*14, "font#t:0:%y#s:0:%s#l:20:0#r#These options will have no effect if the Status Bar is not activated.#" .. textColor3 .. ":l");
 
@@ -790,7 +797,7 @@ module.frame = function()
 	-- Extra Bar
 	if (module.ctExtraBar) then
 		optionsBeginFrame(-20, 0, "frame#tl:0:%y#br:tr:0:%b");
-			optionsAddObject(  0,   17, "font#tl:5:%y#v:GameFontNormalLarge#Extra Bar");
+			optionsAddObject(  0,   17, "font#tl:5:%y#v:GameFontNormal#Extra Bar");
 
 			optionsAddObject( -5, 2*14, "font#t:0:%y#s:0:%s#l:20:0#r#The following options will have no effect if the Extra Bar is not activated.#" .. textColor3 .. ":l");
 			optionsAddObject( -5, 3*14, "font#t:0:%y#s:0:%s#l:20:0#r#The Extra Bar consists of a single button which the game will show when needed (usually during certain boss fights).#" .. textColor2 .. ":l");
@@ -804,7 +811,7 @@ module.frame = function()
 	-- Pet Bar
 	if (module.ctPetBar) then
 		optionsBeginFrame(-30, 0, "frame#tl:0:%y#br:tr:0:%b");
-			optionsAddObject(  0,   17, "font#tl:5:%y#v:GameFontNormalLarge#Pet Bar");
+			optionsAddObject(  0,   17, "font#tl:5:%y#v:GameFontNormal#Pet Bar");
 
 			optionsAddObject( -5, 2*14, "font#t:0:%y#s:0:%s#l:20:0#r#These options will have no effect if the Pet Bar is not activated.#" .. textColor3 .. ":l");
 
@@ -817,7 +824,7 @@ module.frame = function()
 	-- Vehicle Tools Bar
 	if (module.ctVehicleBar) then
 		optionsBeginFrame(-30, 0, "frame#tl:0:%y#br:tr:0:%b");
-			optionsAddObject(  0,   17, "font#tl:5:%y#v:GameFontNormalLarge#Vehicle Tools Bar");
+			optionsAddObject(  0,   17, "font#tl:5:%y#v:GameFontNormal#Vehicle Tools Bar");
 
 			optionsAddObject( -5, 2*14, "font#t:0:%y#s:0:%s#l:20:0#r#These options will have no effect if the Vehicle Tools Bar is not activated.#" .. textColor3 .. ":l");
 			optionsAddObject( -2, 3*14, "font#t:0:%y#s:0:%s#l:20:0#r#If you are in a vehicle with no abilities then a leave vehicle button will be shown on this bar only if the vehicle can be exited.#" .. textColor2 .. ":l");
@@ -886,8 +893,8 @@ function module:optionsInitApplied()
 	-- successfully applied.
 
 	appliedOptions.showCTBarMod = not not module:getOption("showCTBarMod");
-	appliedOptions.dragHideTooltip = not not module:getOption("dragHideTooltip");
-	appliedOptions.clampFrames = not not module:getOption("clampFrames");
+	-- REMOVED IN 8.0.1.5 -- appliedOptions.dragHideTooltip = not not module:getOption("dragHideTooltip");
+	appliedOptions.clampFrames = module:getOption("clampFrames") ~= false;
 
 	appliedOptions.hideGryphons = module:getOption("hideGryphons") ~= false;
 	appliedOptions.showLions = not not module:getOption("showLions");

--- a/CT_BottomBar/CT_BottomBar_TalkingHead.lua
+++ b/CT_BottomBar/CT_BottomBar_TalkingHead.lua
@@ -73,16 +73,8 @@ local function addon_Init(self)
 	end
 	
 	TalkingHeadFrame.ignoreFramePositionManager = true;
-	--TalkingHeadFrame:SetParent(self.frame);
 	
-	--local timeelapsed = 0;
 	hooksecurefunc("TalkingHeadFrame_PlayCurrent", function()
-	--[[TalkingHeadFrame:HookScript("OnUpdate", function(thframe, elapsed)
-	 	timeelapsed = timeelapsed + elapsed;
-	 	if timeelapsed > 0.1 then
-	 		DEFAULT_CHAT_FRAME:AddMessage("test");
-	 		timeelapsed = 0;
-	 	end--]]
 	 	if (CT_BB_TalkingHead_IsEnabled) then
 			TalkingHeadFrame:ClearAllPoints();
 			TalkingHeadFrame:SetPoint("BOTTOM",self.frame,"BOTTOM", 0,0);

--- a/CT_BottomBar/CT_BottomBar_TalkingHead.lua
+++ b/CT_BottomBar/CT_BottomBar_TalkingHead.lua
@@ -1,0 +1,124 @@
+------------------------------------------------
+--               CT_BottomBar                 --
+--                                            --
+-- Breaks up the main menu bar into pieces,   --
+-- allowing you to hide and move the pieces   --
+-- independently of each other.               --
+--                                            --
+-- Please do not modify or otherwise          --
+-- redistribute this without the consent of   --
+-- the CTMod Team. Thank you.                 --
+------------------------------------------------
+
+-- Credit:
+-- CT_BB module written by DDCorkum
+-- Some lines of code borrowed from MoveTalkingHead addon by Ketho (EU-Boulderfist) 
+
+
+--------------------------------------------
+-- Initialization
+
+local _G = getfenv(0);
+local module = _G.CT_BottomBar;
+
+local ctRelativeFrame = module.ctRelativeFrame;
+local appliedOptions;
+
+local CT_BB_TalkingHead_IsEnabled = nil;
+
+--------------------------------------------
+-- Action bar arrows and page number
+
+local function addon_Update(self)
+	-- Update the frame
+	-- self == talking head object
+
+	self.helperFrame:ClearAllPoints();
+	self.helperFrame:SetPoint("TOPLEFT", self.frame, "TOPLEFT", -5, 5);
+	self.helperFrame:SetPoint("BOTTOMRIGHT", self.frame, "BOTTOMRIGHT", 5, -5);
+end
+
+local function addon_Enable(self)
+	CT_BB_TalkingHead_IsEnabled = true;
+	TalkingHeadFrame:ClearAllPoints();
+	TalkingHeadFrame:SetPoint("BOTTOM",self.frame,"BOTTOM", 0,0);
+end
+
+local function addon_Disable(self)
+	CT_BB_TalkingHead_IsEnabled = false;
+	TalkingHeadFrame:ClearAllPoints();
+	TalkingHeadFrame:SetPoint("BOTTOM","UIParent","BOTTOM", 0, 96);
+end
+
+local function addon_Init(self)
+	-- Initialization
+	-- self == actionbar arrows bar object
+
+	appliedOptions = module.appliedOptions;
+
+	module.ctActionBarPage = self;
+
+	local frame = CreateFrame("Frame", "CT_BottomBar_" .. self.frameName .. "_GuideFrame");
+	self.helperFrame = frame;
+	
+	if (not TalkingHeadFrame) then TalkingHead_LoadUI(); end
+	
+	self.frame:SetHeight(155);
+	self.frame:SetWidth(570);
+	
+	for i, alertSubSystem in pairs(AlertFrame.alertFrameSubSystems) do
+		if alertSubSystem.anchorFrame == TalkingHeadFrame then
+			tremove(AlertFrame.alertFrameSubSystems, i);
+		end
+	end
+	
+	TalkingHeadFrame.ignoreFramePositionManager = true;
+	--TalkingHeadFrame:SetParent(self.frame);
+	
+	--local timeelapsed = 0;
+	hooksecurefunc("TalkingHeadFrame_PlayCurrent", function()
+	--[[TalkingHeadFrame:HookScript("OnUpdate", function(thframe, elapsed)
+	 	timeelapsed = timeelapsed + elapsed;
+	 	if timeelapsed > 0.1 then
+	 		DEFAULT_CHAT_FRAME:AddMessage("test");
+	 		timeelapsed = 0;
+	 	end--]]
+	 	if (CT_BB_TalkingHead_IsEnabled) then
+			TalkingHeadFrame:ClearAllPoints();
+			TalkingHeadFrame:SetPoint("BOTTOM",self.frame,"BOTTOM", 0,0);
+		else
+			TalkingHeadFrame:ClearAllPoints();
+			TalkingHeadFrame:SetPoint("BOTTOM","UIParent","BOTTOM", 0, 96);
+		end	
+	end);
+	
+	
+	
+
+	return true;
+end
+
+local function addon_Register()
+	module:registerAddon(
+		"Talking Head",  -- option name
+		"CTTalkingHead",  -- used in frame names
+		"Talking Head",  -- shown in options window & tooltips
+		"Talking",  -- title for horizontal orientation
+		nil,  -- title for vertical orientation
+		{ "BOTTOM", ctRelativeFrame, "BOTTOM", 0, 96 },
+		{ -- settings
+			orientation = "ACROSS",
+		},
+		addon_Init,
+		nil,  -- no post init function
+		nil,  -- no config function
+		addon_Update,
+		nil,  -- no orientation function
+		addon_Enable,
+		addon_Disable,  -- no disable function
+		"helperFrame",
+		TalkingHeadFrame
+	);
+end
+
+module.loadedAddons["Talking Head"] = addon_Register;

--- a/CT_BottomBar/CT_BottomBar_TalkingHead.lua
+++ b/CT_BottomBar/CT_BottomBar_TalkingHead.lua
@@ -103,7 +103,7 @@ local function addon_Register()
 		"Talking Head",  -- option name
 		"CTTalkingHead",  -- used in frame names
 		"Talking Head",  -- shown in options window & tooltips
-		"Talking",  -- title for horizontal orientation
+		"Talking Head (quest dialogue)",  -- title for horizontal orientation
 		nil,  -- title for vertical orientation
 		{ "BOTTOM", ctRelativeFrame, "BOTTOM", 0, 96 },
 		{ -- settings

--- a/CT_BottomBar/changes.txt
+++ b/CT_BottomBar/changes.txt
@@ -1,5 +1,6 @@
 CT_BottomBar (8.0.1.5) 2018-08-15
 - The "talking head" quest dialogue is now movable!  No longer stuck over custom bars.
+- The movable action-bar arrows and action bar are less clunky
 
 CT_BottomBar (8.0.1.3) 2018-07-29
 - Fixed combat taint issue that was introduced in 8.0.1.2

--- a/CT_BottomBar/changes.txt
+++ b/CT_BottomBar/changes.txt
@@ -1,3 +1,5 @@
+CT_BottomBar (8.0.1.5) 2018-08-15
+- The "talking head" quest dialogue is now movable!  No longer stuck over custom bars.
 
 CT_BottomBar (8.0.1.3) 2018-07-29
 - Fixed combat taint issue that was introduced in 8.0.1.2

--- a/CT_Core/CT_Core.lua
+++ b/CT_Core/CT_Core.lua
@@ -265,7 +265,8 @@ module.frame = function()
 		optionsAddObject(  0,   17, "font#tl:5:%y#v:GameFontNormalLarge#Tips");
 		optionsAddObject( -2, 2*14, "font#t:0:%y#s:0:%s#l:13:0#r#You can use /ctcore to open this options window directly.#" .. textColor2 .. ":l");
 		optionsAddObject( -2, 2*14, "font#t:0:%y#s:0:%s#l:13:0#r#You can use /hail to hail your current target. A key binding is also available for this.#" .. textColor2 .. ":l");
-
+		optionsAddObject( -8, 4*13, "font#t:0:%y#s:0:%s#l:13:0#r#Temporary notice:\nStarting in version 8.0105, CT_BottomBar has the option to hide the main-bar gryphons#" .. textColor3 .. ":l");
+		
 	-- Alternate Power Bar
 		optionsAddObject(-20,   17, "font#tl:5:%y#v:GameFontNormalLarge#Alternate Power Bar");
 		optionsAddObject( -2, 5*14, "font#t:0:%y#s:0:%s#l:13:0#r#The game sometimes uses this bar to show the status of a quest, or your status in a fight, etc. The bar can vary in size, and its default position is centered near the bottom of the screen.#" .. textColor2 .. ":l");
@@ -438,11 +439,9 @@ module.frame = function()
 
 	-- General
 		optionsAddObject(-20,   17, "font#tl:5:%y#v:GameFontNormalLarge#General");
-		optionsAddObject( -5,   26, "checkbutton#tl:10:%y#i:hideGryphons#o:hideGryphons#Hide the Main Bar gryphons");
 		optionsAddObject(  6,   26, "checkbutton#tl:10:%y#o:tickMod#Display health/mana regeneration rates");
 		optionsAddObject( -2,   14, "font#tl:60:%y#v:ChatFontNormal#Format:");
 		optionsAddObject( 14,   20, "dropdown#tl:100:%y#s:125:%s#o:tickModFormat#n:CTCoreDropdown1#Health - Mana#HP/Tick - MP/Tick#HP - MP");
-
 	-- Merchant options
 		optionsAddObject(-20,   17, "font#tl:5:%y#v:GameFontNormalLarge#Merchant");
 		optionsAddObject( -5,   26, "checkbutton#tl:10:%y#o:merchantAltClickItem:true#Alt click a merchant's item to buy a stack");

--- a/CT_Core/CT_Core.toc
+++ b/CT_Core/CT_Core.toc
@@ -1,5 +1,5 @@
 ## Interface: 80000
-## Version: 8.0.1.1
+## Version: 8.0.1.5
 ## Title: CT_Core
 ## Notes: General nifty features for CTMod.
 ## DefaultState: Enabled

--- a/CT_Core/CT_Core_Other.lua
+++ b/CT_Core/CT_Core_Other.lua
@@ -1519,46 +1519,6 @@ hooksecurefunc("ContainerFrameItemButton_OnModifiedClick", CT_Core_ContainerFram
 CT_Core_ContainerFrameItemButton_OnModifiedClick_Register(CT_Core_AddToAuctions);
 
 --------------------------------------------
--- Hide Gryphons
-
-local gryphonLoop;
-
-local function toggleGryphons(hide)
-	if (gryphonLoop) then
-		-- Ensure no infinite loop.
-		gryphonLoop = nil;
-		return;
-	end
-	-- Hide/Show the gryphons
-	if ( hide ) then
-		MainMenuBarArtFrame.LeftEndCap:Hide();
-		MainMenuBarArtFrame.RightEndCap:Hide();
-	else
-		MainMenuBarArtFrame.LeftEndCap:Show();
-		MainMenuBarArtFrame.RightEndCap:Show();
-	end
-	if (CT_BottomBar) then
-		-- CT_BottomBar is loaded, and it may also have an option
-		-- to hide the gryphons.
-		local optCore = "hideGryphons";
-		local optBott = "hideGryphons";
-		if (type(module.frame) == "table") then
-			-- Update our "hide gryphons" option checkbox.
-			-- This is needed for those times when CT_BottomBar calls us
-			-- to change the CT_Core "hide gryphons" option.
-			local cb = module.frame.section1[optCore];
-			cb:SetChecked(hide);
-		end
-		if (CT_BottomBar:getOption(optBott) ~= module:getOption(optCore)) then
-			-- Change CT_BottomBar's "hide gryphons" option.
-			gryphonLoop = true;
-			CT_BottomBar:setOption(optBott, hide, true);
-			gryphonLoop = nil;
-		end
-	end
-end
-
---------------------------------------------
 -- Hide World Map Minimap Button
 
 local function toggleWorldMap(hide)
@@ -3031,7 +2991,6 @@ local modFunctions = {
 	["tooltipMouseAnchor"] = setTooltipMouseAnchor,
 	["tooltipFrameDisableFade"] = setTooltipFrameDisableFade,
 	["tooltipMouseDisableFade"] = setTooltipMouseDisableFade,
-	["hideGryphons"] = toggleGryphons,
 	["hideWorldMap"] = toggleWorldMap,
 	["castingbarEnabled"] = castingbar_ToggleStatus,
 	["castingbarMovable"] = castingbar_ToggleMovable,

--- a/CT_Core/changes.txt
+++ b/CT_Core/changes.txt
@@ -1,3 +1,6 @@
+CT_Core (8.0.1.5) 2018-08-18
+- Removed option to hide main-bar gryphons (but the option remains in CT_BottomBar)
+
 CT_Core (8.0.1.1) 2018-07-17
 - Further updates for 8.0.1
 

--- a/CT_Library/CT_Library.lua
+++ b/CT_Library/CT_Library.lua
@@ -11,7 +11,7 @@
 -----------------------------------------------
 -- Initialization
 
-local LIBRARY_VERSION = 8.01040;
+local LIBRARY_VERSION = 8.01050;
 local LIBRARY_NAME = "CT_Library";
 
 local _G = getfenv(0);

--- a/CT_Library/CT_Library.toc
+++ b/CT_Library/CT_Library.toc
@@ -1,5 +1,5 @@
 ## Interface: 80000
-## Version: 8.0.1.4
+## Version: 8.0.1.5
 ## Title: CT_Library
 ## Notes: Library features for CTMod. 
 ## DefaultState: Enabled

--- a/CT_MailMod/CT_MailMod.toc
+++ b/CT_MailMod/CT_MailMod.toc
@@ -1,5 +1,5 @@
 ## Interface: 80000
-## Version: 8.0.1.4
+## Version: 8.0.1.5
 ## Title: CT_MailMod
 ## Notes: Heavily improves the in-game mail functionality.
 ## DefaultState: Enabled

--- a/CT_MailMod/CT_MailMod_StockUI.lua
+++ b/CT_MailMod/CT_MailMod_StockUI.lua
@@ -989,6 +989,7 @@ function InboxFrame_OnClick(self, index)
 		OpenMail_Update();
 		--OpenMailFrame:Show();
 		ShowUIPanel(OpenMailFrame);
+		OpenMailFrameInset:SetPoint("TOPLEFT", 4, -80);
 		PlaySound(829);
 		module:initOpenMail(); -- *new*
 	else

--- a/CT_MailMod/changes.txt
+++ b/CT_MailMod/changes.txt
@@ -1,3 +1,6 @@
+CT_MailMod (8.0.1.5) 2018-08-15
+- Aesthetic adjustment to open mail frame
+
 CT_MailMod (8.0.1.3) 2018-07-28
 - Fixed and improved auto-complete filters
 

--- a/CT_MapMod/CT_MapMod.lua
+++ b/CT_MapMod/CT_MapMod.lua
@@ -131,7 +131,7 @@ local function CT_MapMod_Initialize()		-- called via module.update("init") from 
 			{ ["name"] = "Akunda's Bite", ["icon"] = "Interface\\AddOns\\CT_MapMod\\Resource\\Herb_AkundasBite" },
 			{ ["name"] = "Anchor Weed", ["icon"] = "Interface\\AddOns\\CT_MapMod\\Resource\\Herb_AnchorWeed" },
 			{ ["name"] = "Riverbud", ["icon"] = "Interface\\AddOns\\CT_MapMod\\Resource\\Herb_Riverbud" },
-			{ ["name"] = "Sea Stalk", ["icon"] = "Interface\\AddOns\\CT_MapMod\\Resource\\Herb_SeaStalk" },
+			{ ["name"] = "Sea Stalks", ["icon"] = "Interface\\AddOns\\CT_MapMod\\Resource\\Herb_SeaStalk" },
 			{ ["name"] = "Siren's Song", ["icon"] = "Interface\\AddOns\\CT_MapMod\\Resource\\Herb_Bruiseweed" },
 			{ ["name"] = "Star Moss", ["icon"] = "Interface\\AddOns\\CT_MapMod\\Resource\\Herb_StarMoss" },
 			{ ["name"] = "Winter's Kiss", ["icon"] = "Interface\\AddOns\\CT_MapMod\\Resource\\Herb_WintersKiss" },
@@ -207,12 +207,19 @@ local function CT_MapMod_Initialize()		-- called via module.update("init") from 
 					CT_MapMod_Notes[newmap] = { }; 
 				end					
 				tinsert(CT_MapMod_Notes[newmap],newnote);
-				--wipe(note);
 			end
 		end
-		--wipe(notecollection);
 	end
 	wipe(CT_UserMap_Notes);
+	
+	-- update saved notes from more recent versions (8.0.1.4 onwards) to the current format, as required
+	for mapid, notetable in pairs(CT_MapMod_Notes)
+		for i, note in ipairs(notetable)
+			if (note["set"] == "Herb" and note["subset"] == "Sea Stalk") then note["subset"] = "Sea Stalks"; end		-- Fixing typo in 8.0.1.4
+			-- add here any future changes to the NoteTypes tables
+		end
+		--add here any future changes to mapid
+	end
 
 	-- load the DataProvider which has most of the horsepower
 	WorldMapFrame:AddDataProvider(CreateFromMixins(CT_MapMod_DataProviderMixin));

--- a/CT_MapMod/CT_MapMod.lua
+++ b/CT_MapMod/CT_MapMod.lua
@@ -817,7 +817,7 @@ do
 					GameTooltip:Hide();
 				end
 			},
-			["button#n:CT_MapMod_CreateNoteButton#s:80:16#tl:t:+120:-2#v:UIPanelButtonTemplate#New Pin"] =	{
+			["button#n:CT_MapMod_CreateNoteButton#s:75:16#tr:tr:-125:-3#v:UIPanelButtonTemplate#New Pin"] =	{
 				["onload"] = function(self)
 					WorldMapFrame:AddCanvasClickHandler(function(canvas, button)
 						if (not module.isCreatingNote) then return; end
@@ -864,7 +864,7 @@ do
 					if (not module.isCreatingNote) then GameTooltip:Hide(); end
 				end
 			},
-		["button#n:CT_MapMod_OptionsButton#s:80:16#tl:t:+205:-3#v:UIPanelButtonTemplate#Options"] = {
+		["button#n:CT_MapMod_OptionsButton#s:75:16#tr:tr:-50:-3#v:UIPanelButtonTemplate#Options"] = {
 				["onclick"] = function(self, arg1)
 					module:showModuleOptions(module.name);
 				end,
@@ -877,35 +877,48 @@ do
 					GameTooltip:Hide();
 				end
 			},
-		["frame#n:CT_MapMod_px#s:40:16#tl:t:-240:-3"] = { 
+		["frame#n:CT_MapMod_px#s:40:16#bl:b:-140:0"] = { 
 				["onload"] = function(self)
-					module.px = self:CreateFontString(nil,"ARTWORK","ChatFontNormal");
+					module.px = self
+					self.text = self:CreateFontString(nil,"ARTWORK","ChatFontNormal");
 				end,
 				["onenter"] = function(self)
 					GameTooltip:SetOwner(self, "ANCHOR_TOPLEFT", 30, 15);
-					GameTooltip:SetText("CT: Player Coords");
+					local playerposition = C_Map.GetPlayerMapPosition(WorldMapFrame:GetMapID(),"player");
+					if (playerposition) then
+						GameTooltip:SetText("CT: Player Coords");
+					else
+						GameTooltip:SetText("Player coords not available here");
+					end
 					GameTooltip:Show();
 				end,
 				["onleave"] = function(self)
 					GameTooltip:Hide();
 				end
 			},
-		["frame#n:CT_MapMod_py#s:40:16#tl:t:-200:-3"] =  { 
+		["frame#n:CT_MapMod_py#s:40:16#bl:b:-100:0"] =  { 
 				["onload"] = function(self)
-					module.py = self:CreateFontString(nil,"ARTWORK","ChatFontNormal");
+					module.py = self
+					self.text = self:CreateFontString(nil,"ARTWORK","ChatFontNormal");
 				end,
 				["onenter"] = function(self)
 					GameTooltip:SetOwner(self, "ANCHOR_TOPLEFT", 30, 15);
-					GameTooltip:SetText("CT: Player Coords");
+					local playerposition = C_Map.GetPlayerMapPosition(WorldMapFrame:GetMapID(),"player");
+					if (playerposition) then
+						GameTooltip:SetText("CT: Player Coords");
+					else
+						GameTooltip:SetText("Player coords not available here");
+					end
 					GameTooltip:Show();
 				end,
 				["onleave"] = function(self)
 					GameTooltip:Hide();
 				end
 			},
-		["frame#n:CT_MapMod_cx#s:40:16#tl:t:-140:-3"] =  { 
+		["frame#n:CT_MapMod_cx#s:40:16#bl:b:70:0"] =  { 
 				["onload"] = function(self)
-					module.cx = self:CreateFontString(nil,"ARTWORK","ChatFontNormal");
+					module.cx = self
+					self.text = self:CreateFontString(nil,"ARTWORK","ChatFontNormal");
 				end,
 				["onenter"] = function(self)
 					GameTooltip:SetOwner(self, "ANCHOR_TOPLEFT", 30, 15);
@@ -916,9 +929,10 @@ do
 					GameTooltip:Hide();
 				end
 			},
-		["frame#n:CT_MapMod_cy#s:40:16#tl:t:-100:-3"] =  { 
+		["frame#n:CT_MapMod_cy#s:40:16#bl:b:110:0"] =  { 
 				["onload"] = function(self)
-					module.cy = self:CreateFontString(nil,"ARTWORK","ChatFontNormal");
+					module.cy = self
+					self.text = self:CreateFontString(nil,"ARTWORK","ChatFontNormal");
 
 				end,
 				["onenter"] = function(self)
@@ -946,21 +960,21 @@ do
 				local px, py = playerposition:GetXY();
 				px = math.floor(px*1000)/10;
 				py = math.floor(py*1000)/10;
-				module.px:SetText("x:" .. px);
-				module.py:SetText("y:" .. py);
+				module.px.text:SetText("x:" .. px);
+				module.py.text:SetText("y:" .. py);
 			else
-				module.px:SetText("x: -");
-				module.py:SetText("y: -");
+				module.px.text:SetText("x: -");
+				module.py.text:SetText("y: -");
 			end
 			if (mapid == C_Map.GetBestMapForUnit("player")) then
-				module.px:SetTextColor(1,1,1);
-				module.py:SetTextColor(1,1,1);
+				module.px.text:SetTextColor(1,1,1,1);
+				module.py.text:SetTextColor(1,1,1,1);
 				if ((module:getOption("CT_MapMod_ShowMapResetButton") or 1) == 1) then
 					_G["CT_MapMod_WhereAmIButton"]:Hide();
 				end			
 			else
-				module.px:SetTextColor(.6,.6,.6);			
-				module.py:SetTextColor(.6,.6,.6);
+				module.px.text:SetTextColor(1,1,1,.3);			
+				module.py.text:SetTextColor(1,1,1,.3);
 				if ((module:getOption("CT_MapMod_ShowMapResetButton") or 1) == 1) then
 					_G["CT_MapMod_WhereAmIButton"]:Show();
 				end				
@@ -968,16 +982,20 @@ do
 		end	
 		local cx, cy = WorldMapFrame:GetNormalizedCursorPosition();
 		if (cx and cy) then
+			if (cx > 0 and cx < 1 and cy > 0 and cy < 1) then
+				module.cx.text:SetTextColor(1,1,1,1);
+				module.cy.text:SetTextColor(1,1,1,1);
+			else
+				module.cx.text:SetTextColor(1,1,1,.3);			
+				module.cy.text:SetTextColor(1,1,1,.3);
+			end
 			cx = math.floor(cx*1000)/10;
 			cx = math.max(math.min(cx,100),0);
 			cy = math.floor(cy*1000)/10;
 			cy = math.max(math.min(cy,100),0);				
-			module.cx:SetText("x:" .. cx);
-			module.cy:SetText("y:" .. cy);
-		else
-			-- the cursor is not over the map
-			module.cx:SetText("x:");
-			module.cy:SetText("y:");			
+			module.cx.text:SetText("x:" .. cx);
+			module.cy.text:SetText("y:" .. cy);
+			
 		end
 	end);
 end
@@ -1006,15 +1024,14 @@ do
 								local istooclose = nil;
 								if (not CT_MapMod_Notes[mapid]) then CT_MapMod_Notes[mapid] = { }; end
 								for k, note in ipairs(CT_MapMod_Notes[mapid]) do
-									if ((note["name"] == arg2) and (math.sqrt((note["x"]-x)^2+(note["y"]-y)^2)<.025)) then  --two herbs of the same kind not far apart
+									if ((note["name"] == arg2) and (math.sqrt((note["x"]-x)^2+(note["y"]-y)^2)<.02)) then   --two herbs of the same kind not far apart
 										istooclose = true;
 									end
-									if (math.sqrt((note["x"]-x)^2+(note["y"]-y)^2)<.0125) then --two notes, even if they are different, extremely close together
+									if ((note["set"] == "Herb") and (math.sqrt((note["x"]-x)^2+(note["y"]-y)^2)<.01)) then 	--two herbs of different kinds very close together
 										istooclose = true;
-										if (note["name"] == "Herb" and note["subset"] == "Bruiseweed") then  -- legacy herb from WoD or Legion that can now be updated
-											note["name"] = arg2;
-											note["subset"] = arg2;
-										end
+									end
+									if (math.sqrt((note["x"]-x)^2+(note["y"]-y)^2)<.005) then 		--two notes of completely different kinds EXTREMELY close together
+										istooclose = true;
 									end
 								end
 								if (not istooclose) then
@@ -1027,7 +1044,7 @@ do
 										["descript"] = "",
 										["datemodified"] = date("%Y%m%d"),
 										["version"] = MODULE_VERSION,
-									};
+				m					};
 									tinsert(CT_MapMod_Notes[mapid],newnote);
 								end
 								return;
@@ -1050,10 +1067,13 @@ do
 								local istooclose = nil;
 								if (not CT_MapMod_Notes[mapid]) then CT_MapMod_Notes[mapid] = { }; end
 								for k, note in ipairs(CT_MapMod_Notes[mapid]) do
-									if ((note["name"] == arg2) and (math.sqrt((note["x"]-x)^2+(note["y"]-y)^2)<.03)) then    --two veins of the same kind not far apart
+									if ((note["name"] == arg2) and (math.sqrt((note["x"]-x)^2+(note["y"]-y)^2)<.02)) then   --two veins of the same kind not far apart
 										istooclose = true;
 									end
-									if (math.sqrt((note["x"]-x)^2+(note["y"]-y)^2)<.015) then --two notes, even if they are different, extremely close together
+									if ((note["set"] == "Ore") and (math.sqrt((note["x"]-x)^2+(note["y"]-y)^2)<.01)) then 	--two veins of different kinds very close together
+										istooclose = true;
+									end
+									if (math.sqrt((note["x"]-x)^2+(note["y"]-y)^2)<.005) then 		--two notes of completely different kinds EXTREMELY close together
 										istooclose = true;
 									end
 								end
@@ -1088,11 +1108,14 @@ end
 module.update = function(self, optName, value)
 	if (optName == "init") then		
 		CT_MapMod_Initialize();  -- handles things that arn't related to options
-		
-		local position = module:getOption("CT_MapMod_ShowPlayerCoordsOnMap") or 1;
+		module.px:ClearAllPoints();
+		module.py:ClearAllPoints();
+		module.cx:ClearAllPoints();
+		module.cy:ClearAllPoints();
+		local position = module:getOption("CT_MapMod_ShowPlayerCoordsOnMap") or 2;
 		if (position == 1) then
-			module.px:SetPoint("TOPLEFT",WorldMapFrame.BorderFrame,"TOP",-240,-3);
-			module.py:SetPoint("TOPLEFT",WorldMapFrame.BorderFrame,"TOP",-200,-3);
+			module.px:SetPoint("TOPLEFT",WorldMapFrame.BorderFrame,"TOP",-145,-3);
+			module.py:SetPoint("TOPLEFT",WorldMapFrame.BorderFrame,"TOP",-105,-3);
 		elseif (position == 2) then
 			module.px:SetPoint("BOTTOMLEFT",WorldMapFrame.ScrollContainer,"BOTTOM",-140,3);
 			module.py:SetPoint("BOTTOMLEFT",WorldMapFrame.ScrollContainer,"BOTTOM",-100,3);
@@ -1100,53 +1123,64 @@ module.update = function(self, optName, value)
 			module.px:Hide();
 			module.py:Hide();
 		end
-		position = module:getOption("CT_MapMod_ShowCursorCoordsOnMap") or 1;
+		module.px.text:SetAllPoints();
+		module.py.text:SetAllPoints();
+		position = module:getOption("CT_MapMod_ShowCursorCoordsOnMap") or 2;
 		if (position == 1) then
-			module.cx:SetPoint("TOPLEFT",WorldMapFrame.BorderFrame,"TOP",-140,-3);
-			module.cy:SetPoint("TOPLEFT",WorldMapFrame.BorderFrame,"TOP",-100,-3);
+			module.cx:SetPoint("TOPLEFT",WorldMapFrame.BorderFrame,"TOP",65,-3);
+			module.cy:SetPoint("TOPLEFT",WorldMapFrame.BorderFrame,"TOP",105,-3);
 		elseif (position == 2) then
 			module.cx:SetPoint("BOTTOMLEFT",WorldMapFrame.ScrollContainer,"BOTTOM",70,3);
 			module.cy:SetPoint("BOTTOMLEFT",WorldMapFrame.ScrollContainer,"BOTTOM",110,3);
 		else
 			module.cx:Hide();
 			module.cy:Hide();
-		end			
+		end		
+		module.cx.text:SetAllPoints();
+		module.cy.text:SetAllPoints();
 	elseif (optName == "CT_MapMod_ShowPlayerCoordsOnMap") then
-		if (not module.px and module.py) then return; end
-		module.px:Show();
-		module.py:Show();
+		if (not module.px or not module.py) then return; end
+		module.px:ClearAllPoints();
+		module.py:ClearAllPoints();
 		if (value == 1) then
-			module.px:ClearAllPoints();
-			module.px:SetPoint("TOPLEFT",WorldMapFrame.BorderFrame,"TOP",-240,-3);
-			module.py:ClearAllPoints();
-			module.py:SetPoint("TOPLEFT",WorldMapFrame.BorderFrame,"TOP",-200,-3);
+			module.px:Show();
+			module.py:Show();
+			module.px:SetPoint("TOPLEFT",WorldMapFrame.BorderFrame,"TOP",-145,-3);
+			module.py:SetPoint("TOPLEFT",WorldMapFrame.BorderFrame,"TOP",-105,-3);
 		elseif (value == 2) then
-			module.px:ClearAllPoints();
-			module.px:SetPoint("BOTTOMLEFT",WorldMapFrame.BorderFrame,"BOTTOM",-140,3);
-			module.py:ClearAllPoints();
-			module.py:SetPoint("BOTTOMLEFT",WorldMapFrame.BorderFrame,"BOTTOM",-100,3);		
+			module.px:Show();
+			module.py:Show();
+			module.px:SetPoint("BOTTOMLEFT",WorldMapFrame.ScrollContainer,"BOTTOM",-140,3);
+			module.py:SetPoint("BOTTOMLEFT",WorldMapFrame.ScrollContainer,"BOTTOM",-100,3);		
 		else
 			module.px:Hide();
 			module.py:Hide();
 		end
+		module.px.text:SetAllPoints();
+		module.py.text:SetAllPoints();
 	elseif (optName == "CT_MapMod_ShowCursorCoordsOnMap") then
-		if (not module.cx and module.cy) then return; end
-		module.cx:Show();
-		module.cy:Show();
+		if (not module.cx or not module.cy) then return; end
+
 		if (value == 1) then
+			module.cx:Show();
+			module.cy:Show();
 			module.cx:ClearAllPoints();
-			module.cx:SetPoint("TOPLEFT",WorldMapFrame.BorderFrame,"TOP",-140,-3);
 			module.cy:ClearAllPoints();
-			module.cy:SetPoint("TOPLEFT",WorldMapFrame.BorderFrame,"TOP",-100,-3);
+			module.cx:SetPoint("TOPLEFT",WorldMapFrame.BorderFrame,"TOP",65,-3);
+			module.cy:SetPoint("TOPLEFT",WorldMapFrame.BorderFrame,"TOP",105,-3);
 		elseif (value == 2) then
+			module.cx:Show();
+			module.cy:Show();
 			module.cx:ClearAllPoints();
-			module.cx:SetPoint("BOTTOMLEFT",WorldMapFrame.BorderFrame,"BOTTOM",60,3);
 			module.cy:ClearAllPoints();
-			module.cy:SetPoint("BOTTOMLEFT",WorldMapFrame.BorderFrame,"BOTTOM",100,3);		
+			module.cx:SetPoint("BOTTOMLEFT",WorldMapFrame.ScrollContainer,"BOTTOM",60,3);
+			module.cy:SetPoint("BOTTOMLEFT",WorldMapFrame.ScrollContainer,"BOTTOM",100,3);		
 		else
 			module.cx:Hide();
 			module.cy:Hide();
 		end
+		module.cx.text:SetAllPoints();
+		module.cy.text:SetAllPoints();
 	elseif (optName == "CT_MapMod_ShowMapResetButton") then
 		if (not _G["CT_MapMod_WhereAmIButton"]) then return; end
 		if (value == 2) then _G["CT_MapMod_WhereAmIButton"]:Show(); end
@@ -1220,9 +1254,9 @@ module.frame = function()
 		
 		optionsAddObject(-5,   50, "font#t:0:%y#s:0:%s#l:13:0#r#Coordinates show where you are on the map, and where your mouse cursor is#" .. textColor2 .. ":l");
 		optionsAddObject(-5,   14, "font#t:0:%y#s:0:%s#l:13:0#r#Show player coordinates#" .. textColor1 .. ":l");
-		optionsAddObject(-5,   24, "dropdown#tl:5:%y#s:150:20#o:CT_MapMod_ShowPlayerCoordsOnMap#n:CT_MapMod_ShowPlayerCoordsOnMap#At Top#At Bottom#Disabled");
+		optionsAddObject(-5,   24, "dropdown#tl:5:%y#s:150:20#o:CT_MapMod_ShowPlayerCoordsOnMap:2#n:CT_MapMod_ShowPlayerCoordsOnMap#At Top#At Bottom#Disabled");
 		optionsAddObject(-5,   14, "font#t:0:%y#s:0:%s#l:13:0#r#Show cursor coordinates#" .. textColor1 .. ":l");
-		optionsAddObject(-5,   24, "dropdown#tl:5:%y#s:150:20#o:CT_MapMod_ShowCursorCoordsOnMap#n:CT_MapMod_ShowCursorCoordsOnMap#At Top#At Bottom#Disabled");
+		optionsAddObject(-5,   24, "dropdown#tl:5:%y#s:150:20#o:CT_MapMod_ShowCursorCoordsOnMap:2#n:CT_MapMod_ShowCursorCoordsOnMap#At Top#At Bottom#Disabled");
 		
 		optionsAddObject(-10,  50, "font#t:0:%y#s:0:%s#l:13:0#r#The \"where am I?\" button resets the map to your current zone.  Auto: show when map on wrong zone#" .. textColor2 .. ":l");
 		optionsAddObject(-5,   14, "font#t:0:%y#s:0:%s#l:13:0#r#Show map reset button#" .. textColor1 .. ":l");

--- a/CT_MapMod/CT_MapMod.toc
+++ b/CT_MapMod/CT_MapMod.toc
@@ -1,5 +1,5 @@
 ## Interface: 80000
-## Version: 8.0.4.0
+## Version: 8.0.5.0
 ## Title: CT_MapMod
 ## Notes: Adds the ability to write notes on the worldmap and send/receive to/from other players.
 ## DefaultState: Enabled

--- a/CT_MapMod/changes.txt
+++ b/CT_MapMod/changes.txt
@@ -1,3 +1,7 @@
+CT_MapMod (8.0.1.5) 2018-08-14
+- Further updates for new BFA Zones
+- Added at transparency (alpha) option for pins
+
 CT_MapMod (8.0.1.4) 2018-08-11
 - Completely re-written from the ground up
 - Backwards compatible with notes from 7.3

--- a/CT_MapMod/changes.txt
+++ b/CT_MapMod/changes.txt
@@ -1,6 +1,7 @@
-CT_MapMod (8.0.1.5) 2018-08-14
+CT_MapMod (8.0.1.5) 2018-08-25
 - Further updates for new BFA Zones
 - Added at transparency (alpha) option for pins
+- Some buttons on the map can be moved, for compatibility with other addons
 
 CT_MapMod (8.0.1.4) 2018-08-11
 - Completely re-written from the ground up

--- a/CT_RaidAssist/CT_RACache.lua
+++ b/CT_RaidAssist/CT_RACache.lua
@@ -1,7 +1,7 @@
 -- This is the first file to get loaded, so some stuff will get set here to be sure its available elsewhere.
 
 CT_RA_NumGroups = 8;  -- When sorting by group this is 8, when sorting by class this is the number of classes in the game.
-CT_RA_MaxGroups = 11;  -- This is the maximum number of possible groups (when sorting by group or class).
+CT_RA_MaxGroups = 12;  -- This is the maximum number of possible groups (when sorting by group or class).
 
 -- Ensure the ClickCastFrames table exists, since we'll be using adding some of our frames to it.
 ClickCastFrames = ClickCastFrames or { };
@@ -25,6 +25,7 @@ CT_RA_CLASS_WARLOCK_EN = "WARLOCK";
 CT_RA_CLASS_WARRIOR_EN = "WARRIOR";
 CT_RA_CLASS_DEATHKNIGHT_EN = "DEATHKNIGHT";
 CT_RA_CLASS_MONK_EN = "MONK";
+CT_RA_CLASS_DEMONHUNTER_EN = "DEMONHUNTER";
 
 
 function CT_RA_UnitName(unit)

--- a/CT_RaidAssist/CT_RAClassSpells.lua
+++ b/CT_RaidAssist/CT_RAClassSpells.lua
@@ -36,19 +36,6 @@ end
 
 function CT_RA_GetClassTalents()
 	CT_RA_ClassTalents = { };
---[[
-	-- WoW 4
-	local name, iconPath, tier, column, currentRank, maxRank;
-	for i = 1, GetNumTalentTabs(), 1 do
-		for y = 1, GetNumTalents(i), 1 do
-			name, iconPath, tier, column, currentRank, maxRank = GetTalentInfo(i, y);
-			if (name and currentRank and currentRank > 0) then
-				CT_RA_ClassTalents[name] = currentRank;
-			end
-		end
-	end
---]]
-	-- WoW 5
 	local id, name, description, iconPath, background, role;
 	local currentRank;
 	for i = 1, GetNumSpecializations(), 1 do

--- a/CT_RaidAssist/CT_RAMenu.xml
+++ b/CT_RaidAssist/CT_RAMenu.xml
@@ -2635,6 +2635,8 @@ C:\Projects\WoW\Bin\Interface\FrameXML\UI.xsd">
 							</Frame>
 							<Frame name="$parentDebuffsClass11" id="11" inherits="CT_RAMenuNotifyClassTemplate">
 							</Frame>
+							<Frame name="$parentDebuffsClass12" id="12" inherits="CT_RAMenuNotifyClassTemplate">
+							</Frame>
 						</Frames>
 						<Scripts>
 							<OnShow>

--- a/CT_RaidAssist/CT_RAOptions.xml
+++ b/CT_RaidAssist/CT_RAOptions.xml
@@ -739,6 +739,15 @@ C:\Projects\WoW\Bin\Interface\FrameXML\UI.xsd">
 					</Anchor>
 				</Anchors>
 			</CheckButton>
+			<CheckButton name="CT_RAOptions2ClassCB12" inherits="CT_RaCheckButtonClassTemplate" id="12">
+				<Anchors>
+					<Anchor point="TOPLEFT" relativePoint="BOTTOMLEFT" relativeTo="CT_RAOptions2ClassCB11">
+						<Offset>
+							<AbsDimension x="135" y="0"/>
+						</Offset>
+					</Anchor>
+				</Anchors>
+			</CheckButton>
 			<CheckButton name="CT_RASortWindowPositions" hidden="false" inherits="OptionsCheckButtonTemplate">
 				<HitRectInsets>
 					<AbsInset left="0" right="0" top="0" bottom="0"/>

--- a/CT_RaidAssist/CT_RASets.lua
+++ b/CT_RaidAssist/CT_RASets.lua
@@ -70,18 +70,18 @@ CT_RA_REZ_REINCARNATION = (GetSpellInfo(27740)) or "Reincarnation"; -- (see Stat
 -- .icon == Icon texture name (no path, just the file name).
 CT_RA_BuffSpellData = {
 	[1]  = { spellid = 21562, opt =       9 }, -- Power Word: Fortitude
-	[2]  = { spellid =  1126, opt =       9 }, -- Mark of the Wild
-	[3]  = { spellid =  1459, opt =       9 }, -- Arcane Brilliance
+--	[2]  = { spellid =  1126, opt =       9 }, -- Mark of the Wild  (removed in CTRA 8.0.1.5)
+	[3]  = { spellid =  1459, opt =       9 }, -- Arcane Intellect/Brilliance
 --	[4]  = { spellid =   nil, opt =       9 }, -- ? (Number 4 hasn't been used in a long time)
 --	[5]  = { spellid = 27683, opt =       9 }, -- Shadow Protection (Not in WoW 5.04)
 	[6]  = { spellid =    17, opt =  2      }, -- Power Word: Shield
 	[7]  = { spellid = 20707, opt =      8  }, -- Soulstone Resurrection
 --	[8]  = { spellid = 16875, opt =       9 }, -- Divine Spirit (Not in WoW 4.0.1)
 --	[9]  = { spellid =   467, opt =     7   }, -- Thorns (Not in WoW 5.04)
-	[10] = { spellid =  6346, opt =   5     }, -- Fear Ward
-	[11] = { spellid = 19740, opt =       9 }, -- Blessing of Might
+--	[10] = { spellid =  6346, opt =   5     }, -- Fear Ward  (removed in CTRA 8.0.1.5)
+--	[11] = { spellid = 19740, opt =       9 }, -- Blessing of Might (removed in CTRA 8.0.1.5)
 --	[12] = { spellid = 56521, opt =       9 }, -- Blessing of Wisdom (Not in WoW 4.0.1)
-	[13] = { spellid = 20217, opt =       9 }, -- Blessing of Kings
+--	[13] = { spellid = 20217, opt =       9 }, -- Blessing of Kings (removed in CTRA 8.0.1.5)
 --	[14] = { spellid =   nil, opt =       9 }, -- Blessing of Salvation (Not in WoW 4.0.1)
 --	[15] = { spellid = 32770, opt =       9 }, -- Blessing of Light (Not in WoW 4.0.1)
 --	[16] = { spellid =   nil, opt =       9 }, -- Blessing of Sanctuary (Not in WoW 4.0.1)
@@ -93,40 +93,21 @@ CT_RA_BuffSpellData = {
 	[22] = { spellid = 33763, opt = 1       }, -- Lifebloom
 	[23] = { spellid = 48438, opt = 1       }, -- Wild Growth
 	[24] = { spellid = 33076, opt = 1       }, -- Prayer of Mending (added in CTRA 4.003)
-	[25] = { spellid = 61316, opt =       9 }, -- Dalaran Brilliance (added in CTRA 4.003, was previously bundled with Arcane Intellect, etc)
+--	[25] = { spellid = 61316, opt =       9 }, -- Dalaran Brilliance (added in CTRA 4.003, remoted in CTRA 8.0.1.5
 };
 
 -- Fill in other data using GetSpellInfo()
 for num, spellData in pairs(CT_RA_BuffSpellData) do
 	local name, rank, icon, cost, isFunnel, powerType, castTime, minRange, maxRange;
 	local spellid = spellData["spellid"];
---	if (type(spellid) == "table") then
---		for i, id in pairs(spellid) do
---			name, rank, icon, cost, isFunnel, powerType, castTime, minRange, maxRange = GetSpellInfo(id);
---			if (not spellData["name"]) then
---				spellData["name"] = {};
---			end
---			if (not spellData["icon"]) then
---				spellData["icon"] = {};
---			end
---			if (not spellData["name"][i]) then
---				spellData["name"][i] = name or UNKNOWN or "Unknown";
---			end
---			if (not spellData["icon"][i]) then
---				spellData["icon"][i] = icon or "Interface\\Icons\\Spell_Holy_WordFortitude";
---				spellData["icon"][i] = gsub(spellData["icon"][i], "^Interface\\Icons\\(.+)$", "%1");
---			end
---		end
---	elseif (spellid) then
-		name, rank, icon, cost, isFunnel, powerType, castTime, minRange, maxRange = GetSpellInfo(spellid);
-		if (not spellData["name"]) then
-			spellData["name"] = name or UNKNOWN or "Unknown";
-		end
-		if (not spellData["icon"]) then
-			spellData["icon"] = icon or "Interface\\Icons\\Spell_Holy_WordFortitude";
-			spellData["icon"] = gsub(spellData["icon"], "^Interface\\Icons\\(.+)$", "%1");
-		end
---	end
+	name, rank, icon, cost, isFunnel, powerType, castTime, minRange, maxRange = GetSpellInfo(spellid);
+	if (not spellData["name"]) then
+		spellData["name"] = name or UNKNOWN or "Unknown";
+	end
+	if (not spellData["icon"]) then
+		spellData["icon"] = icon; -- or "Interface\\Icons\\Spell_Holy_WordFortitude";
+		--spellData["icon"] = gsub(spellData["icon"], "^Interface\\Icons\\(.+)$", "%1");
+	end
 end
 
 -- Build table of internal id numbers indexed by buff name.

--- a/CT_RaidAssist/CT_RaidAssist.lua
+++ b/CT_RaidAssist/CT_RaidAssist.lua
@@ -1341,15 +1341,17 @@ function CT_RA_OnEvent(self, event, arg1, arg2, ...)
 	end
 end
 
-CT_RA_oldUseSoulstone = UseSoulstone;
-function CT_RA_newUseSoulstone()
-	local text = HasSoulstone();
-	if ( text and text == CT_RA_REZ_REINCARNATION ) then  -- Shaman
-		CT_RA_AddMessage("CD 2 30");
+--[[	-- HasSoulstone() no longer appears to be a valid instruction.
+	CT_RA_oldUseSoulstone = UseSoulstone;
+	function CT_RA_newUseSoulstone()
+		local text = HasSoulstone();
+		if ( text and text == CT_RA_REZ_REINCARNATION ) then  -- Shaman
+			CT_RA_AddMessage("CD 2 30");
+		end
+		CT_RA_oldUseSoulstone();
 	end
-	CT_RA_oldUseSoulstone();
-end
-UseSoulstone = CT_RA_newUseSoulstone;
+	UseSoulstone = CT_RA_newUseSoulstone;
+--]]
 
 -----------------------------------------------------
 --                  Update Functions               --
@@ -4686,7 +4688,7 @@ StaticPopupDialogs["RESURRECT_NO_TIMER"].OnShow = function(self) oldDialogs["RES
 StaticPopupDialogs["RESURRECT"].OnHide = function() CT_RA_AddMessage("NORESSED") end;
 StaticPopupDialogs["RESURRECT_NO_SICKNESS"].OnHide = function() CT_RA_AddMessage("NORESSED") end;
 StaticPopupDialogs["RESURRECT_NO_TIMER"].OnHide = function() if ( not StaticPopup_FindVisible("DEATH") ) then CT_RA_AddMessage("NORESSED") end end;
-StaticPopupDialogs["DEATH"].OnShow = function(self) oldDialogs["DEATHSHOW"](self) if ( HasSoulstone() ) then CT_RA_AddMessage("CANRES") end end;
+StaticPopupDialogs["DEATH"].OnShow = function(self) oldDialogs["DEATHSHOW"](self) if ( ResurrectGetOfferer() and not ResurrectHasSickness() ) then CT_RA_AddMessage("CANRES") end end;
 
 -- Hook StaticPopup_OnShow
 hooksecurefunc("StaticPopup_OnShow", function(self)

--- a/CT_RaidAssist/CT_RaidAssist.lua
+++ b/CT_RaidAssist/CT_RaidAssist.lua
@@ -37,6 +37,7 @@ CT_RA_ClassPositions = {
 	[CT_RA_CLASS_SHAMAN] = 9,
 	[CT_RA_CLASS_DEATHKNIGHT] = 10,
 	[CT_RA_CLASS_MONK] = 11,
+	[CT_RA_CLASS_DEMONHUNTER] = 12,
 };
 CT_RA_ClassIndices = {
 	"WARRIOR",
@@ -50,6 +51,7 @@ CT_RA_ClassIndices = {
 	"SHAMAN",
 	"DEATHKNIGHT",
 	"MONK",
+	"DEMONHUNTER",
 };
 CT_RA_ClassSorted = {};
 for k, v in pairs(CT_RA_ClassPositions) do
@@ -81,7 +83,7 @@ CT_RA_NumRaidMembers = 0;
 
 function CT_RA_ClassUsesMana(class)
 	-- Returns true if specified class uses mana.
-	return not (class == CT_RA_CLASS_WARRIOR or class == CT_RA_CLASS_ROGUE or class == CT_RA_CLASS_DEATHKNIGHT or class == CT_RA_CLASS_HUNTER);
+	return not (class == CT_RA_CLASS_WARRIOR or class == CT_RA_CLASS_ROGUE or class == CT_RA_CLASS_DEATHKNIGHT or class == CT_RA_CLASS_HUNTER or class == CT_RA_CLASS_DEMONHUNTER);
 end
 
 function CT_RA_HideClassManaBar(class)
@@ -244,8 +246,16 @@ function CT_RA_SetGroup(num, show)
 	if (not sortOptions["ShowGroups"]) then
 		sortOptions["ShowGroups"] = {};
 	end
-	sortOptions["ShowGroups"][num] = show;
-	sortOptions["HiddenGroups"] = nil;
+	if (not sortOptions["HiddenGroups"]) then
+		sortOptions["HiddenGroups"] = {};
+	end
+	if (show) then
+		sortOptions["ShowGroups"][num] = 1;
+		sortOptions["HiddenGroups"][num] = nil
+	else
+		sortOptions["HiddenGroups"][num] = 1;
+		sortOptions["ShowGroups"][num] = nil;
+	end
 	CT_RA_LoadSortOptions_ShowHideWindows();
 end
 
@@ -256,8 +266,16 @@ function CT_RA_SetClass(num, show)
 	if (not sortOptions["ShowGroups"]) then
 		sortOptions["ShowGroups"] = {};
 	end
-	sortOptions["ShowGroups"][num] = show;
-	sortOptions["HiddenGroups"] = nil;
+	if (not sortOptions["HiddenGroups"]) then
+		sortOptions["HiddenGroups"] = {};
+	end
+	if (show) then
+		sortOptions["ShowGroups"][num] = 1;
+		sortOptions["HiddenGroups"][num] = nil
+	else
+		sortOptions["HiddenGroups"][num] = 1;
+		sortOptions["ShowGroups"][num] = nil;
+	end
 	CT_RA_LoadSortOptions_ShowHideWindows();
 end
 
@@ -641,20 +659,6 @@ function CT_RA_ParseMessage(nick, msg)
 			end
 			name = spellData["name"];
 			icon = spellData["icon"];
---			if ( type(name) == "table" ) then
---				if ( val3 ) then
---					name = name[val3];
---				else
---					return update;
---				end
---			end
---			if ( type(icon) == "table" ) then
---				if ( val3 ) then
---					icon = icon[val3];
---				else
---					return update;
---				end
---			end
 		end
 		if ( not name ) then
 			return update;
@@ -1664,15 +1668,6 @@ function CT_RA_UpdateUnitBuffs(buffs, frame, nick)
 					spellData = next(CT_RA_BuffSpellData);
 				end
 				local name, texName;
---				if ( type(spellData["name"]) == "table" ) then
---					local t = spellData["name"]; -- t == Table of 'equivalent' buff names
---					for n = 1, #t do
---						if ( buffs[ (t[n]) ] ) then
---							name = t[n];
---							texName = spellData["icon"][n];
---							break;
---						end
---					end
 				if ( buffs[ (spellData["name"]) ] ) then
 					name = spellData["name"];
 					texName = spellData["icon"];
@@ -1680,7 +1675,7 @@ function CT_RA_UpdateUnitBuffs(buffs, frame, nick)
 				if ( name and texName ) then
 					if ( num <= 4 and val["show"] ~= -1 ) then -- Change 4 to number of buffs
 						local button = frame["BuffButton"..num];
-						frameCache[button].Icon:SetTexture("Interface\\Icons\\" .. texName);
+						frameCache[button].Icon:SetTexture(texName);
 						button.name = name;
 						button.owner = nick;
 						button.texture = texName;

--- a/CT_RaidAssist/CT_RaidAssist.toc
+++ b/CT_RaidAssist/CT_RaidAssist.toc
@@ -1,5 +1,5 @@
 ## Interface: 80000
-## Version: 8.0.1.1
+## Version: 8.0.1.5
 ## Title: CT_RaidAssist
 ## Notes: Allows you to monitor Raid HP.
 ## DefaultState: Enabled

--- a/CT_RaidAssist/CT_RaidAssist.xml
+++ b/CT_RaidAssist/CT_RaidAssist.xml
@@ -493,6 +493,7 @@ C:\Projects\WoW\Bin\Interface\FrameXML\UI.xsd">
 			<Frame name="CT_RAGroup9" inherits="CT_RAGroupTemplate" parent="UIParent" id="9" hidden="true"/>
 			<Frame name="CT_RAGroup10" inherits="CT_RAGroupTemplate" parent="UIParent" id="10" hidden="true"/>
 			<Frame name="CT_RAGroup11" inherits="CT_RAGroupTemplate" parent="UIParent" id="11" hidden="true"/>
+			<Frame name="CT_RAGroup12" inherits="CT_RAGroupTemplate" parent="UIParent" id="12" hidden="true"/>
 			<Frame name="CT_RAMTGroup" inherits="CT_RAGroupTemplate" parent="UIParent" id="21" hidden="true"/>
 			<Frame name="CT_RAMTTGroup" inherits="CT_RAGroupTemplate" parent="UIParent" id="22" hidden="true"/>
 			<Frame name="CT_RAPTGroup" inherits="CT_RAGroupTemplate" parent="UIParent" id="23" hidden="true"/>
@@ -648,6 +649,20 @@ C:\Projects\WoW\Bin\Interface\FrameXML\UI.xsd">
 				<Scripts>
 					<OnLoad>
 						CT_RA_LinkDrag(CT_RAGroup11, self, "TOP", "TOP", 0, -14);
+					</OnLoad>
+				</Scripts>
+			</Frame>
+			<Frame name="CT_RAGroupDrag12" inherits="CT_RAGroupDragTemplate" id="12" parent="UIParent" hidden="false">
+				<Anchors>
+					<Anchor point="TOPLEFT" relativePoint="TOPLEFT">
+						<Offset>
+							<AbsDimension x="475" y="-375"/>
+						</Offset>
+					</Anchor>
+				</Anchors>
+				<Scripts>
+					<OnLoad>
+						CT_RA_LinkDrag(CT_RAGroup12, self, "TOP", "TOP", 0, -14);
 					</OnLoad>
 				</Scripts>
 			</Frame>

--- a/CT_RaidAssist/changes.txt
+++ b/CT_RaidAssist/changes.txt
@@ -1,3 +1,7 @@
+CT_RaidAssit (8.0.1.5) 2018-08-17
+- Updated class buff icons
+- Added demon-hunter group
+
 CT_RaidAssist (8.0.1.3) 2018-07-27
 - Changing some legacy code to avoid future taint issues.
 - Updated SendAddonMessage() for 8.0.1

--- a/CT_RaidAssist/changes.txt
+++ b/CT_RaidAssist/changes.txt
@@ -1,6 +1,7 @@
-CT_RaidAssit (8.0.1.5) 2018-08-17
-- Updated class buff icons
+CT_RaidAssist (8.0.1.5) 2018-08-21
+- Updated class buff icons to BFA
 - Added demon-hunter group
+- Fixed HasSoulstone() error
 
 CT_RaidAssist (8.0.1.3) 2018-07-27
 - Changing some legacy code to avoid future taint issues.

--- a/CT_RaidAssist/localization.lua
+++ b/CT_RaidAssist/localization.lua
@@ -56,6 +56,7 @@ CT_RA_CLASS_SHAMAN = "Shaman";
 CT_RA_CLASS_PALADIN = "Paladin";
 CT_RA_CLASS_DEATHKNIGHT = "Death Knight";
 CT_RA_CLASS_MONK = "Monk";
+CT_RA_CLASS_DEMONHUNTER = "Demon Hunter";
 
 -- Messages
 CT_RA_MESSAGE_AFK = "You are now Away: (.+)";

--- a/CT_UnitFrames/CT_PlayerFrame.lua
+++ b/CT_UnitFrames/CT_PlayerFrame.lua
@@ -65,3 +65,36 @@ function CT_PetFrame_TextStatusBar_UpdateTextString(bar)
 end
 hooksecurefunc("TextStatusBar_UpdateTextString", CT_PetFrame_TextStatusBar_UpdateTextString);
 
+local playerelapsed = 0;
+local isfirsttime = true;
+function CT_PlayerFrame_PlayerCoords()
+	if (CT_UnitFramesOptions.playerCoordsRight) then
+		CT_PlayerCoordsRight:Show();
+		if (isfirsttime) then
+			isfirsttime = false;
+			CT_PlayerFrame:HookScript("OnUpdate", function(self, elapsed)
+				playerelapsed = playerelapsed + elapsed;
+				if (playerelapsed < 1) then return; end
+				playerelapsed = 0;
+				local mapid = C_Map.GetBestMapForUnit("player");
+				if (mapid) then
+					local playerposition = C_Map.GetPlayerMapPosition(mapid,"player");
+					if (playerposition) then
+						local px, py = playerposition:GetXY();
+						if (not px or not py) then return; end  -- don't think this can ever happen
+						px = math.floor(px*100);
+						py = math.floor(py*100);
+						CT_PlayerCoordsRight:SetText(px .. "," .. py);
+					else
+						CT_PlayerCoordsRight:SetText("");
+					end
+				else
+					CT_PlayerCoordsRight:SetText("");
+				end
+			end);
+		end
+	else
+		CT_PlayerCoordsRight:Hide();
+	end
+end
+

--- a/CT_UnitFrames/CT_PlayerFrame.xml
+++ b/CT_UnitFrames/CT_PlayerFrame.xml
@@ -25,6 +25,16 @@ C:\Projects\WoW\Bin\Interface\FrameXML\UI.xsd">
 						</Anchor>
 					</Anchors>
 				</FontString>
+				<FontString name="CT_PlayerCoordsRight" inherits="GameFontNormalSmall" text="">
+					<Anchors>
+						<Anchor point="LEFT" relativeTo="PlayerFrame" relativePoint="TOPRIGHT">
+							<Offset>
+								<AbsDimension x="-3.4" y="-30"/>
+							</Offset>
+						</Anchor>
+					</Anchors>
+				</FontString>
+				
 			</Layer>
 		</Layers>
 		<Scripts>

--- a/CT_UnitFrames/CT_UnitFrameOptions.lua
+++ b/CT_UnitFrames/CT_UnitFrameOptions.lua
@@ -90,6 +90,7 @@ function CT_UnitFramesOptions_Box_OnLoad(self)
 	_G[self:GetName() .. "Name"]:SetText(CT_UFO_BOX[self:GetID()]);
 	if ( self:GetID() == 1 ) then
 		_G[self:GetName() .. "PlayerTextLeftCBName"]:SetText(CT_UFO_TEXTLEFT);
+		_G[self:GetName() .. "PlayerCoordsRightCBName"]:SetText(CT_UFO_SHOWCOORDS);
 	elseif ( self:GetID() == 3 ) then
 		_G[self:GetName() .. "ClassFrameCBName"]:SetText(CT_UFO_TARGETCLASS);
 		_G[self:GetName() .. "TargetTextRightCBName"]:SetText(CT_UFO_TEXTRIGHT);
@@ -122,6 +123,9 @@ function CT_UnitFrameOptions_OnEvent(self, event, ...)
 		CT_UnitFramesOptionsFrameBox5LockCB:Enable();
 	elseif (event == "PLAYER_LOGIN") then
 		local fixLeft, fixEnemy;
+
+		-- added in 8.0.1.5.
+		CT_UnitFramesOptions.playerCoordsRight = not not CT_UnitFramesOptions.playerCoordsRight;
 
 		-- Assign default values if any rows are missing, and upgrade current users if needed.
 		if (not CT_UnitFramesOptions["styles"]) then
@@ -235,6 +239,7 @@ function CT_UnitFramesOptions_Radio_Update()
 	end
 
 	CT_UnitFramesOptionsFrameBox1PlayerTextLeftCB:SetChecked(CT_UnitFramesOptions.playerTextLeft);
+	CT_UnitFramesOptionsFrameBox1PlayerCoordsRightCB:SetChecked(CT_UnitFramesOptions.playerCoordsRight);
 	CT_UnitFramesOptionsFrameBox3ClassFrameCB:SetChecked(CT_UnitFramesOptions.displayTargetClass);
 	CT_UnitFramesOptionsFrameBox3TargetTextRightCB:SetChecked(CT_UnitFramesOptions.targetTextRight);
 	CT_UnitFramesOptionsFrameBox4DisplayCB:SetChecked(CT_UnitFramesOptions.shallDisplayAssist);
@@ -328,6 +333,10 @@ function CT_UnitFramesOptions_Box_CB_OnClick(self)
 			-- "Show health/mana on left"
 			CT_UnitFramesOptions.playerTextLeft = self:GetChecked();
 			CT_PlayerFrame_AnchorSideText();
+		elseif (self:GetID() == 63) then
+			-- "Show player coordinates"
+			CT_UnitFramesOptions.playerCoordsRight = self:GetChecked();
+			CT_PlayerFrame_PlayerCoords();
 		end
 	elseif ( self:GetParent():GetID() == 3 ) then
 		-- Box3
@@ -591,6 +600,8 @@ module.update = function(self, type, value)
 		end
 
 		CT_UnitFrameOptions_SetOptionsFrame("player");
+		
+		CT_PlayerFrame_PlayerCoords()
 	else
 
 	end

--- a/CT_UnitFrames/CT_UnitFrameOptions.xml
+++ b/CT_UnitFrames/CT_UnitFrameOptions.xml
@@ -525,6 +525,40 @@ C:\Projects\WoW\Bin\Interface\FrameXML\UI.xsd">
 							</Layer>
 						</Layers>
 					</CheckButton>
+					<CheckButton name="$parentPlayerCoordsRightCB" id="63" hidden="false" inherits="OptionsCheckButtonTemplate">
+						<HitRectInsets>
+							<AbsInset left="0" right="0" top="0" bottom="0"/>
+						</HitRectInsets>
+						<Size>
+							<AbsDimension x="24" y="24"/>
+						</Size>
+						<Anchors>
+							<Anchor point="TOPLEFT">
+								<Offset>
+									<AbsDimension x="25" y="-85"/>
+								</Offset>
+							</Anchor>
+						</Anchors>
+						<Scripts>
+							<OnClick>
+								CT_UnitFramesOptions_Box_CB_OnClick(self);
+							</OnClick>
+						</Scripts>
+						<Layers>
+							<Layer level="ARTWORK">
+								<FontString name="$parentName" inherits="GameFontNormalSmall">
+									<Anchors>
+										<Anchor point="LEFT" relativePoint="RIGHT">
+											<Offset>
+												<AbsDimension x="4" y="0"/>
+											</Offset>
+										</Anchor>
+									</Anchors>
+									<Color r="1" g="1" b="1"/>
+								</FontString>
+							</Layer>
+						</Layers>
+					</CheckButton>
 					<Slider name="$parentTextSpacing" inherits="OptionsSliderTemplate">
 						<Size>
 							<AbsDimension x="400" y="17"/>

--- a/CT_UnitFrames/CT_UnitFrames.toc
+++ b/CT_UnitFrames/CT_UnitFrames.toc
@@ -1,5 +1,5 @@
 ## Interface: 80000
-## Version: 8.0.1.0
+## Version: 8.0.1.5
 ## Title: CT_UnitFrames
 ## Notes: Changes display of hp/mana values and adds a percentage.
 ## DefaultState: Enabled

--- a/CT_UnitFrames/changes.txt
+++ b/CT_UnitFrames/changes.txt
@@ -1,3 +1,6 @@
+CT_UnitFrames (8.0.1.5) 2018-08-21
+- Added option to show player coords next to player frame.  (default: not shown)
+
 CT_UnitFrames (8.0.1.0) 2018-07-17
 - Updated for 8.0.1
 

--- a/CT_UnitFrames/localization.lua
+++ b/CT_UnitFrames/localization.lua
@@ -16,3 +16,4 @@ CT_UFO_LEFTSPACING = "Beside health/mana bar spacing = ";
 CT_UFO_RIGHTSPACING = "Beside health/mana bar spacing = ";
 CT_UFO_TEXTRIGHT = "Show health/mana on right side";
 CT_UFO_TEXTLEFT = "Show health/mana on left side";
+CT_UFO_SHOWCOORDS = "Show player coordinates";


### PR DESCRIPTION


8.0.1.5 (25 Aug)

- Tentatively Fixed: HasSoulstone() error when someone dies (CT_RaidAssist)

- Fixed: Group/class selections and class buff icons in raid frames (CT_RaidAssist)

- Fixed: Appearance of the "open mail" mailbox frame (CT_MailMod)

- Fixed: Some BFA herb nodes were not tracked on the map (CT_MapMod)

- New: More control over the appearance of map pins and buttons (CT_MapMod)

- New: The "talking-head" (quest dialogue) frame is now movable (CT_BottomBar)

- New: Option to display character coords next to player frame (CT_UnitFrames)
