### PR TITLE
8.3.0.3

### DIFF
--- a/CT_BarMod/CT_BarMod.toc
+++ b/CT_BarMod/CT_BarMod.toc
@@ -1,5 +1,5 @@
 ## Interface: 80300
-## Version: 8.3.0.1
+## Version: 8.3.0.3
 ## Title: CT_BarMod |cFF333333(BFA)
 ## Notes: Intuitive yet powerful action bar addon.
 ## DefaultState: Enabled

--- a/CT_BarMod/CT_BarMod_ActionButton.lua
+++ b/CT_BarMod/CT_BarMod_ActionButton.lua
@@ -392,7 +392,7 @@ end
 function actionButton:setClickDirection(down, clicks)
 	if (down) then
 		--if (clicks) then
-			self.button:RegisterForClicks("AnyDown");
+	--		self.button:RegisterForClicks("AnyDown");
 		--else
 		--	self.button:RegisterForClicks("LeftButtonUp", "RightButtonUp", "MiddleButtonUp", "Button4Down", "Button5Down");
 		--end
@@ -400,7 +400,7 @@ function actionButton:setClickDirection(down, clicks)
 		--if (clicks) then
 		--	self.button:RegisterForClicks("LeftButtonDown");
 		--else
-			self.button:RegisterForClicks("AnyUp");
+	--		self.button:RegisterForClicks("AnyUp");
 		--end
 	end
 end

--- a/CT_BarMod/CT_BarMod_ActionButton.lua
+++ b/CT_BarMod/CT_BarMod_ActionButton.lua
@@ -340,7 +340,10 @@ function actionButton:constructor(buttonId, actionId, groupId, count, noInherit,
 
 	--self:setClickDirection( not not module:getOption("clickDirection"), not not module:getOption("clickIncluded") );
 	local GetCVar = GetCVar or C_CVar.GetCVar;
-	self:setClickDirection(GetCVar("ActionButtonUseKeyDown") == "1");		-- "1" is the default value, meaning activate abilities when you press DOWN
+	self:setClickDirection(
+		GetCVar("ActionButtonUseKeyDown") == "1",		-- "1" is the default value, meaning activate abilities when you press DOWN
+		module:getOption("onMouseDown")				-- this will be ignored if the CVar is disabled
+	);		
 	
 	button:RegisterForDrag("LeftButton", "RightButton");
 	button:SetAttribute("type", "action");
@@ -389,20 +392,14 @@ function actionButton:setMode(newMode)
 end
 
 -- Set if action is triggered on click up or click down.
-function actionButton:setClickDirection(down, clicks)
-	if (down) then
-		--if (clicks) then
-	--		self.button:RegisterForClicks("AnyDown");
-		--else
-		--	self.button:RegisterForClicks("LeftButtonUp", "RightButtonUp", "MiddleButtonUp", "Button4Down", "Button5Down");
-		--end
+-- This affects the mouse for ALL bars, and also the keybind for extra bars (7-10).
+-- Keybinds for bars 2-6 and the action bar are handled elsewhere in a way that is integrated with console variable "ActionButtonUseKeyDown"
+function actionButton:setClickDirection(onKeyDown, alsoOnMouseDown)
+	if (onKeyDown and alsoOnMouseDown) then
+		self.button:RegisterForClicks("AnyDown");
 	else
-		--if (clicks) then
-		--	self.button:RegisterForClicks("LeftButtonDown");
-		--else
-	--		self.button:RegisterForClicks("AnyUp");
-		--end
-	end
+		self.button:RegisterForClicks("AnyUp");
+	end		
 end
 
 -- Change a button's scale

--- a/CT_BarMod/CT_BarMod_Edit.lua
+++ b/CT_BarMod/CT_BarMod_Edit.lua
@@ -1,1 +1,0 @@
--- depreciated; this file will be removed in a future version of CT_BarMod

--- a/CT_BarMod/CT_BarMod_EditOptions.lua
+++ b/CT_BarMod/CT_BarMod_EditOptions.lua
@@ -1,1 +1,0 @@
--- depreciated; this file will be removed in a future version of CT_BarMod

--- a/CT_BarMod/CT_BarMod_KeyBindings.lua
+++ b/CT_BarMod/CT_BarMod_KeyBindings.lua
@@ -1012,6 +1012,15 @@ local function setActionBindings(event)
 						if (key2) then
 							SetOverrideBinding(owner, false, key2, action);
 						end
+					else
+						-- This simulates CVar.GetCVarBool("ActionButtonUseKeyDown") found in protected function ActionButtonDown()
+						local key1, key2 = module.getBindingKey(baseNum + buttonNum );
+						if (key1) then
+							SetOverrideBinding(owner, false, key1, action);
+						end
+						if (key2) then
+							SetOverrideBinding(owner, false, key2, action);
+						end						
 					end
 				end
 			end

--- a/CT_BarMod/CT_BarMod_KeyBindings.lua
+++ b/CT_BarMod/CT_BarMod_KeyBindings.lua
@@ -949,7 +949,7 @@ local function setActionBindings(event)
 			local owner = groupObj.frame;
 			local showBar = module:getOption("showGroup" .. groupId) ~= false;
 			local useDefault;  -- Assign override bindings to CT_BarMod buttons using default UI's keys.
-			local overrideActions;  -- Assign override bindings to actions using CT_BarMod's keys.
+			--local overrideActions;  -- Assign override bindings to actions using CT_BarMod's keys.   -- removed in 8.3.0.3, see comment below
 
 			-- Clear the current override bindings for this bar.
 			ClearOverrideBindings(owner);
@@ -968,10 +968,13 @@ local function setActionBindings(event)
 					-- We are in a pet battle or the override bar is showing
 					-- 1. Leave the main action bar's override bindings cleared.
 					useDefault = false;
-					-- 2. Assign override bindings to the actions "ACTIONBUTTON1"
-					--    through "ACTIONBUTTON12" using the keys that are currently
-					--    assigned to the buttons on CT_BarMod's action bar (bar 12).
-					overrideActions = true;
+				
+					--[[ Removing in 8.3.0.3, see comment further below
+						-- 2. Assign override bindings to the actions "ACTIONBUTTON1"
+						--    through "ACTIONBUTTON12" using the keys that are currently
+						--    assigned to the buttons on CT_BarMod's action bar (bar 12).
+						--overrideActions = true;
+					--]]
 				end
 			elseif (groupId == 2) then
 				useDefault = module:getOption("bar3Bindings") ~= false;
@@ -996,13 +999,16 @@ local function setActionBindings(event)
 						local key1, key2 = GetBindingKey(action);
 						-- Assign override binding clicks to the CT_BarMod button.
 						if (key1) then
-							SetOverrideBindingClick(owner, false, key1, buttonObj.name);
+							SetOverrideBinding(owner, false, key1, action);
 						end
 						if (key2) then
-							SetOverrideBindingClick(owner, false, key2, buttonObj.name);
+							SetOverrideBinding(owner, false, key2, action);
 						end
 					end
-					if (overrideActions) then
+					-- if (overrideActions) then -- conditional removed in 8.3.0.3:
+								     -- previously this was only used going into a pet battle or vehicle,
+								     -- but now its always used to take advantage of Blizzard's secure implementation of console variable ActionButtonUseKeyDown
+					do
 						-- Get the key(s) currently assigned to the CT_BarMod button.
 						local key1, key2 = module.getBindingKey(baseNum + buttonNum );
 						-- Assign override bindings to the action.
@@ -1010,17 +1016,8 @@ local function setActionBindings(event)
 							SetOverrideBinding(owner, false, key1, action);
 						end
 						if (key2) then
-							SetOverrideBinding(owner, false, key2, action);
+							SetOverrideBinding(owner, false, key2, action);	
 						end
-					else
-						-- This simulates CVar.GetCVarBool("ActionButtonUseKeyDown") found in protected function ActionButtonDown()
-						local key1, key2 = module.getBindingKey(baseNum + buttonNum );
-						if (key1) then
-							SetOverrideBinding(owner, false, key1, action);
-						end
-						if (key2) then
-							SetOverrideBinding(owner, false, key2, action);
-						end						
 					end
 				end
 			end

--- a/CT_BarMod/CT_BarMod_Options.lua
+++ b/CT_BarMod/CT_BarMod_Options.lua
@@ -1012,9 +1012,9 @@ module.frame = function()
 				if (timeElapsed < 0.25) then return; end
 				timeElapsed = 0;
 				if (GetCVar("ActionButtonUseKeyDown") == "1") then
-					CT_BarMod_ToggleKeyFontString:SetText("Currently responding to |cFFFFFF99 mouse/key press down");
+					CT_BarMod_ToggleKeyFontString:SetText("Currently responds to mouse up & |cFFFFFF99 key down|n|cFF999999(only applies to bars 3-6 and the action bar)");
 				else
-					CT_BarMod_ToggleKeyFontString:SetText("Currently responding to |cFFFFFF99 mouse/key release up");
+					CT_BarMod_ToggleKeyFontString:SetText("Currently responds to mouse up & |cFFFFFF99 key up");
 				end
 			end);
 			optionsAddScript("onenter", function(button)
@@ -1023,12 +1023,14 @@ module.frame = function()
 					"Toggles console variable 'ActionButtonUseKeyDown' between 0 and 1", 
 					" ", 
 					"|cFFFFFF99Action on Key Release Up:", 
-					"- Same as typing /console ActionButtonUseKeyDown 0", 
-					"- Game buttons will respond when key/mouse released", 
+					"- Same as typing /console ActionButtonUseKeyDown |cFFFFFFFF0", 
+					"- |cFFFFFFFFAll|r buttons will respond to |cFFFFFFFFmouse-up|r and |cFFFFFFFFkey-up", 
 					" ", 
 					"|cFFFFFF99Action on Key Press Down:", 
-					"- Same as typing /console ActionButtonUseKeyDown 1", 
-					"- Game buttons will respond when key/mouse pressed (Game Default)", 
+					"- Same as typing /console ActionButtonUseKeyDown |cFFFFFFFF1", 
+					"- |cFFFFFFFFMost|r buttons will respond to |cFFFFFFFFpressing the key down", 
+					"- However, Blizzard restricts extra action bars (7 to 10) to key-up only",
+					"- All buttons will still respond to |cFFFFFFFFmouse-up|r (so you can drag)",
 					" ", 
 					"|cFF666666Console variables persist even if you get rid of addons",
 					"|cFF666666but can be reset by typing /console cvar_reset"

--- a/CT_BarMod/CT_BarMod_Options.lua
+++ b/CT_BarMod/CT_BarMod_Options.lua
@@ -1040,8 +1040,7 @@ module.frame = function()
 					"|cFFFFFF99Action on Key Press Down:", 
 					"- Same as typing /console ActionButtonUseKeyDown |cFFFFFFFF1", 
 					"- Bars 2-6 and the action bar will respond to |cFFFFFFFFpressing the key down", 
-					"- Unlocks an option to also use mouse-click down",
-					"  -> This added option also allows bars 7-10 to use key press down",
+					"- Unlocks further options for mouse clicking and bars 7-10",
 					" ", 
 					"|cFF666666Console variables persist even if you get rid of addons",
 					"|cFF666666but can be reset by typing /console cvar_reset"

--- a/CT_BarMod/CT_BarMod_Use.lua
+++ b/CT_BarMod/CT_BarMod_Use.lua
@@ -1186,10 +1186,10 @@ end
 
 -- another cache to improve the performance of useButton:getBinding()
 local checkedBindingActions = {}
-local checkBindingAction = function(key, buttonId)
-	-- Confirms that the binding really does point to CT_BarMod and hasn't been overriden by some other addon
+local checkBindingAction = function(key, buttonId, actionExpected)
+	-- Confirms that the binding really does point to CT_BarMod and hasn't been overriden to something else
 	if (checkedBindingActions[key] == nil) then
-		checkedBindingActions[key] = ("CLICK CT_BarModActionButton" .. buttonId .. ":LeftButton" == GetBindingAction(key, true))
+		checkedBindingActions[key] = (actionExpected == GetBindingAction(key, true))
 	end
 	return checkedBindingActions[key]
 end
@@ -1253,9 +1253,9 @@ function useButton:getBinding()
 	if (showBar and showDef and self.actionName) then
 		-- Get the key used on the default action bar's corresponding button.
 		local key1, key2 = getActionBindingKey(self.actionName .. self.buttonNum);
-		if (key1 and checkBindingAction(key1, id)) then
+		if (key1 and checkBindingAction(key1, id, self.actionName .. self.buttonNum)) then
 			text = key1;
-		elseif (key2 and checkBindingAction(key2, id)) then
+		elseif (key2 and checkBindingAction(key2, id, self.actionName .. self.buttonNum)) then
 			text = key2;
 		end
 	end
@@ -1263,9 +1263,9 @@ function useButton:getBinding()
 	if (not text) then
 		-- Get the key assigned directly to this (our) button.
 		local key1, key2 = module.getBindingKey(id);
-		if (key1 and checkBindingAction(key1, id)) then			--checkBindingAction detects potential interference from other addons using SetOverrideBinding()
+		if (key1 and checkBindingAction(key1, id, (self.actionName and (self.actionName .. self.buttonNum)) or "CLICK CT_BarModActionButton" .. id .. ":LeftButton")) then			--checkBindingAction detects potential interference from other addons using SetOverrideBinding()
 			text = key1;
-		elseif (key2 and checkBindingAction(key2, id)) then
+		elseif (key2 and checkBindingAction(key2, id, (self.actionName and (self.actionName .. self.buttonNum)) or "CLICK CT_BarModActionButton" .. id .. ":LeftButton")) then
 			text = key2;
 		else
 			return;

--- a/CT_BarMod/changes.txt
+++ b/CT_BarMod/changes.txt
@@ -1,3 +1,6 @@
+CT_BarMod (8.3.0.3) 2020-01-20
+- Further integration with /console ActionButtonUseKeyDown
+
 CT_BarMod (8.3.0.1) 2020-01-06
 - Fix to pet battles, relating to 8.2.5.9 and 8.1.5.1
 - Integrated with /console ActionButtonUseKeyDown

--- a/CT_BottomBar/CT_BottomBar.toc
+++ b/CT_BottomBar/CT_BottomBar.toc
@@ -1,5 +1,5 @@
 ## Interface: 80300
-## Version: 8.3.0.2
+## Version: 8.3.0.3
 ## Title: CT_BottomBar |cFF333333(BFA)
 ## Notes: Breaks up the main menu bar into movable pieces.
 ## DefaultState: Enabled

--- a/CT_BottomBar/CT_BottomBar_FPS.lua
+++ b/CT_BottomBar/CT_BottomBar_FPS.lua
@@ -110,7 +110,14 @@ local function addon_Register()
 	module:registerAddon(
 		"Framerate Bar",  -- option name
 		"Frameratebar",  -- used in frame names
-		module.text["CT_BottomBar/Options/FPSBar"],  -- shown in options window & tooltips
+		module.text["CT_BottomBar/Options/FPSBar"] .. 
+			(
+				(
+					GetBindingKey("TOGGLEFPS") 
+					and " (" .. GetBindingKey("TOGGLEFPS") .. ")"
+				)
+				or ""
+			),  -- shown in options window & tooltips
 		module.text["CT_BottomBar/Options/FPSBar"],  -- title for horizontal orientation
 		nil,  -- title for vertical orientation
 		{ "BOTTOMLEFT", ctRelativeFrame, "BOTTOM", -20, 120 },

--- a/CT_BottomBar/changes.txt
+++ b/CT_BottomBar/changes.txt
@@ -1,3 +1,6 @@
+CT_BottomBar (8.3.0.3) 2019-01-16
+- Small tweak to options menu
+
 CT_BottomBar (8.3.0.2) 2019-01-16
 - Minor code cleanup; nothing substantive
 

--- a/CT_BottomBar/localization.lua
+++ b/CT_BottomBar/localization.lua
@@ -34,7 +34,7 @@ L["CT_BottomBar/Options/ClassicKeyRingButton"] = "Key Ring Button"
 L["CT_BottomBar/Options/ClassicPerformanceBar"] = "Performance Bar"
 L["CT_BottomBar/Options/ExpBar"] = "Experience Bar"
 L["CT_BottomBar/Options/FlightBar"] = "Stop Flying Button"
-L["CT_BottomBar/Options/FPSBar"] = "FPS Indicator (CTRL-R)"
+L["CT_BottomBar/Options/FPSBar"] = "FPS Indicator"
 L["CT_BottomBar/Options/General/BackgroundTextures/Heading"] = "Background Textures"
 L["CT_BottomBar/Options/General/BackgroundTextures/HideActionBarCheckButton"] = "Hide the action bar textures"
 L["CT_BottomBar/Options/General/BackgroundTextures/HideGryphonsCheckButton"] = "Hide the gryphons/lions"
@@ -64,7 +64,7 @@ L["CT_BottomBar/Options/ClassicKeyRingButton"] = "Le trousseau de clés"
 L["CT_BottomBar/Options/ClassicPerformanceBar"] = "La performance"
 L["CT_BottomBar/Options/ExpBar"] = "L'expérience"
 L["CT_BottomBar/Options/FlightBar"] = "Le bouton d'arrêt-vol"
-L["CT_BottomBar/Options/FPSBar"] = "Les images/seconde (CTRL-R)"
+L["CT_BottomBar/Options/FPSBar"] = "Les images/seconde"
 L["CT_BottomBar/Options/MovableBars/Activate"] = "Activer"
 L["CT_BottomBar/Options/MovableBars/Hide"] = "Cacher"
 L["CT_BottomBar/Options/MenuBar"] = "Le menu"
@@ -73,5 +73,16 @@ L["CT_BottomBar/Options/RepBar"] = "La réputation"
 L["CT_BottomBar/Options/StanceBar"] = "La position"
 L["CT_BottomBar/Options/StatusBar"] = "Les statuts (PX & rép)"
 L["CT_BottomBar/Options/TalkingHead"] = "Le discours de quête"
+
+
+-----------------------------------------------
+-- deDE (credit: 00jones00)
+
+elseif (GetLocale() == "deDE") then
+
+L["CT_BottomBar/Options/BagsBar"] = "Taschen Leiste"
+L["CT_BottomBar/Options/ClassBar"] = "Klassen Leiste"
+L["CT_BottomBar/Options/ExpBar"] = "Erfahrungsleiste"
+L["CT_BottomBar/Options/FPSBar"] = "FPS Anzeige"
 
 end

--- a/CT_BuffMod/CT_BuffMod.toc
+++ b/CT_BuffMod/CT_BuffMod.toc
@@ -1,5 +1,5 @@
 ## Interface: 80300
-## Version: 8.3.0.1
+## Version: 8.3.0.3
 ## Title: CT_BuffMod |cFF333333(BFA)
 ## Notes: Customizable buff display.
 ## DefaultState: Enabled

--- a/CT_BuffMod/changes.txt
+++ b/CT_BuffMod/changes.txt
@@ -1,3 +1,6 @@
+CT_BuffMod (8.3.0.3) 2020-01-20
+- Localization
+
 CT_BuffMod (8.3.0.1) 2019-01-01
 - Minor code cleanup; nothing substantive
 

--- a/CT_BuffMod/localization.lua
+++ b/CT_BuffMod/localization.lua
@@ -29,6 +29,7 @@ L["CT_BuffMod/TimeFormat/Minutes Plural"] = "%d minutes"
 L["CT_BuffMod/TimeFormat/Minutes Smaller"] = "%d min"
 L["CT_BuffMod/TimeFormat/Minutes Two Digits"] = "%.2dm"
 L["CT_BuffMod/TimeFormat/Off"] = "Off"
+L["CT_BuffMod/TimeFormat/Second Singular"] = "1 second"
 L["CT_BuffMod/TimeFormat/Seconds Abbreviated"] = "%ds"
 L["CT_BuffMod/TimeFormat/Seconds Plural"] = "%d seconds"
 L["CT_BuffMod/TimeFormat/Seconds Smaller"] = "%d sec"
@@ -185,7 +186,6 @@ L["CT_BuffMod/Options/WindowControls/WindowSelectedMessage"] = "Window %d select
 
 if (GetLocale() == "frFR") then
 
-
 L["CT_BuffMod/PRE_EXPIRATION_WARNING"] = "L'aura |cFFFFFFFF%s|r expire dans |cFFFFFFFF%s|r."
 L["CT_BuffMod/PRE_EXPIRATION_WARNING_KEYBINDING"] = "L'aura |cFFFFFFFF%s|r expire dans |cFFFFFFFF%s|r.  Appuyer sur |cFFFFFFFF%s|r pour le réappliquer"
 L["CT_BuffMod/TimeFormat/Day Singular"] = "1 jour"
@@ -205,6 +205,7 @@ L["CT_BuffMod/TimeFormat/Minutes Plural"] = "%d minutes"
 L["CT_BuffMod/TimeFormat/Minutes Smaller"] = "%d min"
 L["CT_BuffMod/TimeFormat/Minutes Two Digits"] = "%.2dm"
 L["CT_BuffMod/TimeFormat/Off"] = "Fermé"
+L["CT_BuffMod/TimeFormat/Second Singular"] = "1 seconde"
 L["CT_BuffMod/TimeFormat/Seconds Abbreviated"] = "%ds"
 L["CT_BuffMod/TimeFormat/Seconds Plural"] = "%d secondes"
 L["CT_BuffMod/TimeFormat/Seconds Smaller"] = "%d sec"
@@ -248,6 +249,7 @@ L["CT_BuffMod/Options/Window/Border/RightSliderValue"] = "La bordure droite = <v
 L["CT_BuffMod/Options/Window/Border/ShowBorderCheckbox"] = "Montrer les bordures"
 L["CT_BuffMod/Options/Window/Border/TopSliderValue"] = "La bordure supérieure = <value>"
 L["CT_BuffMod/Options/Window/Button/General/DebuffBorderColorCheckbox"] = "Changer la bordure des auras nocives"
+L["CT_BuffMod/Options/Window/Button/General/DebuffColorTooltip"] = "Légende : |cFF9600FFmalédiction|r, |cFF966400maladie|r,|cFF3296FFmagie|r, |cFF009600poison|r, et |cFFc80000d'autres (ie, physique)|r."
 L["CT_BuffMod/Options/Window/Button/General/IconSizeSliderLabel"] = "Le grandeur de l'icône :"
 L["CT_BuffMod/Options/Window/Button/General/ShowDaysCheckbox"] = "Montrer des jours si plus de 24 heures"
 L["CT_BuffMod/Options/Window/Button/General/TimeFormatLabel"] = "Le format :"
@@ -279,6 +281,13 @@ L["CT_BuffMod/Options/Window/General/PositionLockedCheckbox"] = "Verrouiller la 
 L["CT_BuffMod/Options/Window/General/PositionResetButton"] = "Remettre la fenêtre"
 L["CT_BuffMod/Options/Window/General/PositionResetTip"] = [=[Ceci place la fenêtre 
 au milieu de l'écran]=]
+L["CT_BuffMod/Options/Window/Layout/BuffSpacingSlider"] = "L'écartement des auras = <value>"
+L["CT_BuffMod/Options/Window/Layout/HorizontalMaxWrapsSlider"] = "Le nombre de rangs = <value>"
+L["CT_BuffMod/Options/Window/Layout/HorizontalWrapAfterSlider"] = "Auras dans chaque rang = <value>"
+L["CT_BuffMod/Options/Window/Layout/HorizontalWrapSpacingSlider"] = "L'écartement des rangs = <value>"
+L["CT_BuffMod/Options/Window/Layout/VerticalMaxWrapsSlider"] = "Le nombre de colonnes = <value>"
+L["CT_BuffMod/Options/Window/Layout/VerticalWrapAfterSlider"] = "Auras dans chaque colonne = <value>"
+L["CT_BuffMod/Options/Window/Layout/VerticalWrapSpacingSlider"] = "L'écartement des colonnes = <value>"
 L["CT_BuffMod/Options/Window/Sorting/Heading"] = "L'ordre des auras"
 L["CT_BuffMod/Options/Window/Sorting/NonExpiringBuffsDropdown"] = "#Avant des autre auras#Après des autre auras#Avec des autre auras"
 L["CT_BuffMod/Options/Window/Sorting/NonExpiringBuffsLabel"] = "Les auras permanents :"
@@ -433,11 +442,13 @@ L["CT_BuffMod/Options/Window/General/PositionClampedCheckbox"] = "Fenster innerh
 L["CT_BuffMod/Options/Window/General/PositionLockedCheckbox"] = "Fenster fixieren, sodass es nicht beweglich ist"
 L["CT_BuffMod/Options/Window/General/PositionResetButton"] = "Fensterposition zurücksetzen"
 L["CT_BuffMod/Options/Window/General/PositionResetTip"] = "Verschiebt das Fenster in die Bildschirmmitte."
+L["CT_BuffMod/Options/Window/Layout/BuffSpacingSlider"] = "Zauberabstand = <value>"
 L["CT_BuffMod/Options/Window/Layout/Heading"] = "Anordnung"
 L["CT_BuffMod/Options/Window/Layout/HorizontalLayoutTip"] = "Für diese Anordnung resultiert das Festlegen der Zeilenanzahl auf 0 in einer variablen Anzahl von Zeilen."
 L["CT_BuffMod/Options/Window/Layout/HorizontalMaxWrapsSlider"] = "Zeilenanzahl = <value>"
 L["CT_BuffMod/Options/Window/Layout/HorizontalWrapAfterSlider"] = "Zauber pro Zeile = <value>"
 L["CT_BuffMod/Options/Window/Layout/HorizontalWrapSpacingSlider"] = "Zeilenabstand = <value>"
+L["CT_BuffMod/Options/Window/Layout/LayoutDropdown"] = "#Oben nach unten. Nach rechts sortieren.#Oben nach unten. Nach links sortieren.#Unten nach oben. Nach rechts sortieren.#Unten nach oben. Nach links sortieren.#Links nach rechts. Abwärts sortieren.#Links nach rechts. Aufwärts sortieren.#Rechts nach links. Abwärts sortieren.#Rechts nach links. Aufwärts sortieren."
 L["CT_BuffMod/Options/Window/Layout/LayoutDropdownLabel"] = "Richtung:"
 L["CT_BuffMod/Options/Window/Layout/MaxWrapsSliderAuto"] = "0 (automatisch erweitern)"
 L["CT_BuffMod/Options/Window/Layout/Tooltip"] = [=[|cFFFFFFFFLegt die Anordnung der Zaubersymbole im Fenster fest. 
@@ -509,6 +520,15 @@ L["CT_BuffMod/Options/WindowControls/WindowClonedMessage"] = "Fenster %d mit Ein
 L["CT_BuffMod/Options/WindowControls/WindowDeletedMessage"] = "Fenster %d entfernt."
 L["CT_BuffMod/Options/WindowControls/WindowSelectedMessage"] = "Fenster %d ausgewählt."
 
+
+elseif (GetLocale() == "ruRU") then
+
+L["CT_BuffMod/Options/Blizzard Frames/Hide Buffs"] = "Скрыть стандартное окно бафов"
+L["CT_BuffMod/Options/General/Expiration/ChatMessageCheckbox"] = "Включить предупреждение в чате"
+L["CT_BuffMod/Options/General/Expiration/DurationHeading"] = "Длительность бафа"
+L["CT_BuffMod/Options/General/Expiration/FlashSliderLabel"] = [=[Мигать иконкой
+перед окончанием:]=]
+L["CT_BuffMod/Options/General/Expiration/PlaySoundCheckbox"] = "Проигрывать звук при предупреждении"
 
 
 end

--- a/CT_Library/changes.txt
+++ b/CT_Library/changes.txt
@@ -1,3 +1,6 @@
+CT_Library (8.3.0.3) 2020-01-18
+- Avoid lua errors when missing a string of localised text
+
 CT_Library (8.3.0.1) 2019-01-12
 - No longer using LibUIDropDownMenu; replacing with foxlit's workarounds published at Townlong Yak
 - Added tool for modules to resolve conflicts with other addons

--- a/CT_Library/localization.lua
+++ b/CT_Library/localization.lua
@@ -18,9 +18,16 @@
 
 -- Please see CurseForge.com/Projects/CTMod/Localization to contribute additional translations
 
-local lib = _G["CT_Library"]
-lib.text = lib.text or { }
-local L = lib.text
+local module = select(2,...)
+module.text = module.text or { }
+local L = module.text
+
+--  Gracefully handle errors
+local metatable = getmetatable(L) or {}
+metatable.__index = function(table, missingKey)
+	return "[Not Found: " .. gsub(missingKey, "CT_Library/", "") .. "]";
+end
+setmetatable(L, metatable);
 
 
 -----------------------------------------------

--- a/CT_MapMod/CT_MapMod.lua
+++ b/CT_MapMod/CT_MapMod.lua
@@ -1330,9 +1330,11 @@ do
 		if (event == "UNIT_SPELLCAST_SENT" and arg1 == "player") then
 			if (InCombatLockdown() or IsInInstance()) then return; end
 			local mapid = C_Map.GetBestMapForUnit("player");
-			if (not mapid) then return; end
-			local x,y = C_Map.GetPlayerMapPosition(mapid,"player"):GetXY();
-			if (not x or not y or (x == 0 and y == 0)) then return; end
+			if (not mapid) then return; end					-- could be nil when the player isn't on any real map
+			local position = C_Map.GetPlayerMapPosition(mapid,"player");
+			if not (position) then return; end				-- could be nil in places like the Warlords of Draenor garrison
+			local x,y = position:GetXY();
+			if (not x or not y or (x == 0 and y == 0)) then return; end	-- could be nil or 0 in dungeons and raids to prevent cheating
 			local herbskills = { 2366, 2368, 3570, 11993, 28695, 50300, 74519, 110413, 158745, 265819, 265821, 265823, 265825, 265827, 265829, 265831, 265834, 265835 }
 			local oreskills =  { 2575, 2576, 3564, 10248, 29354, 50310, 74517, 102161, 158754, 195122, 265837, 265839, 265841, 265843, 265845, 265847, 265849, 265851, 265854 }
 			if ((module:getOption("CT_MapMod_AutoGatherHerbs") or 1) == 1) then
@@ -1389,8 +1391,9 @@ do
 							if (arg2:sub(1,9) == "Filon de " and arg2:len() > 10) then arg2 = arg2:sub(10,10):upper() .. arg2:sub(11); end -- changes "Filon de cuivre" to "Cuivre"
 							if (arg2:sub(1,12) == "Gisement de " and arg2:len() > 13) then arg2 = arg2:sub(13,13):upper() .. arg2:sub(14); end -- changes "Gisement de fer" to "Fer"
 							if (arg2:sub(1,9) == "Veine de " and arg2:len() > 10) then arg2 = arg2:sub(10,10):upper() .. arg2:sub(11); end -- changes "Veine de gangreschiste" to "Gangreschiste"
-							elseif (GetLocale() == "deDE") then
-							-- need to add german modifiers
+						elseif (GetLocale() == "deDE") then
+							if (arg2:sub(1,9) == "Reiches " and arg2:len() > 9) then arg2 = arg2:sub(10); end  -- changes "Reiches Thoriumvorkommen" to "Thoriumvorkommen"
+							if (arg2:sub(-9) == "vorkommen" and arg2:len() > 9) then arg2 = arg2:sub(1, -10); end -- changes "Kupfervorkommen" to "Kupfer"
 						elseif (GetLocale() == "ruRU") then
 							if (arg2:sub(1,8) == "Богатая " and arg2:len() > 9) then arg2 = arg2:sub(9,9):upper() .. arg2:sub(10); end -- changes "Богатая ториевая жила" to "Ториевая жила"
 							if (arg2:sub(-5) == " жила" and arg2:len() > 5) then arg2 = arg2:sub(1,-6); end	--changes "Медная жила" to "Медная"

--- a/CT_MapMod/CT_MapMod.toc
+++ b/CT_MapMod/CT_MapMod.toc
@@ -1,5 +1,5 @@
 ## Interface: 80300
-## Version: 8.3.0.1
+## Version: 8.3.0.3
 ## Title: CT_MapMod |cFF333333(BFA)
 ## Notes: Pins the World Map with points of interest and herb/ore nodes
 ## DefaultState: Enabled

--- a/CT_MapMod/changes.txt
+++ b/CT_MapMod/changes.txt
@@ -1,3 +1,7 @@
+CT_MapMod (8.3.0.3) 2020-01-16
+- Fix to error inside WoD garrison
+- Adding more support for German herbs, ore
+
 CT_MapMod (8.2.5.9) 2019-12-18
 - TOC fix
 

--- a/CT_RaidAssist/CT_RaidAssist.lua
+++ b/CT_RaidAssist/CT_RaidAssist.lua
@@ -2481,8 +2481,8 @@ function NewCTRAPlayerFrame(parentInterface, parentFrame)
 			local combatRezToCast = { };
 			local hasRez = nil;
 			for __, details in ipairs(module.CTRA_Configuration_RezAbilities[class]) do
-				if (GetSpellInfo(L["CT_RaidAssist/Spells/" .. details.name]) and details.combat and (details.gameVersion == nil or details.gameVersion == module:getGameVersion()) and combatRezToCast[details.modifier] == nil) then
-					combatRezToCast[details.modifier] = L["CT_RaidAssist/Spells/" .. details.name];
+				if (GetSpellInfo(details.name) and details.combat and (details.gameVersion == nil or details.gameVersion == module:getGameVersion()) and combatRezToCast[details.modifier] == nil) then
+					combatRezToCast[details.modifier] = details.name;
 					hasRez = true;
 				end
 			end
@@ -2500,8 +2500,8 @@ function NewCTRAPlayerFrame(parentInterface, parentFrame)
 			local nocombatRezToCast = { };
 			local hasRez = nil;
 			for __, details in ipairs(module.CTRA_Configuration_RezAbilities[class]) do
-				if (GetSpellInfo(L["CT_RaidAssist/Spells/" .. details.name]) and details.nocombat and (details.gameVersion == nil or details.gameVersion == module:getGameVersion()) and nocombatRezToCast[details.modifier] == nil) then
-					nocombatRezToCast[details.modifier] = L["CT_RaidAssist/Spells/" .. details.name];
+				if (GetSpellInfo(details.name) and details.nocombat and (details.gameVersion == nil or details.gameVersion == module:getGameVersion()) and nocombatRezToCast[details.modifier] == nil) then
+					nocombatRezToCast[details.modifier] = details.name;
 					hasRez = true;
 				end
 			end
@@ -2512,9 +2512,7 @@ function NewCTRAPlayerFrame(parentInterface, parentFrame)
 		return nil;
 	end
 
-	-- returns two tables:
-	--    the first table has nomod, mod:shift, mod:ctrl or mod:alt as a key and then a valid spellName as a value
-	--    the second table is a simple list of debuffs the player can do something about where [1] is magic, [2] is curse, [3] is poison and [4] is disease, and the value is the name of the spell whose cooldown should be checked
+	-- returns a table with nomod, mod:shift, mod:ctrl or mod:alt as a key and then a valid spellName as a value
 	local canRemoveDebuff = function()				
 		local __, class = UnitClass("player");
 		local spec = GetInspectSpecialization("player");
@@ -2522,8 +2520,8 @@ function NewCTRAPlayerFrame(parentInterface, parentFrame)
 			local friendlyRemovesToCast = { };
 			local hasFriendlyRemoves = nil;
 			for __, details in ipairs(module.CTRA_Configuration_FriendlyRemoves[class]) do
-				if (GetSpellInfo(L["CT_RaidAssist/Spells/" .. details.name]) and (details.gameVersion == nil or details.gameVersion == module:getGameVersion()) and friendlyRemovesToCast[details.modifier] == nil and (details.spec == nil or spec == nil or details.spec == spec)) then
-					friendlyRemovesToCast[details.modifier] = L["CT_RaidAssist/Spells/" .. details.name];
+				if (GetSpellInfo(details.name) and (details.gameVersion == nil or details.gameVersion == module:getGameVersion()) and friendlyRemovesToCast[details.modifier] == nil and (details.spec == nil or spec == nil or details.spec == spec)) then
+					friendlyRemovesToCast[details.modifier] = details.name;
 					hasFriendlyRemoves = true;
 				end
 			end
@@ -2543,8 +2541,8 @@ function NewCTRAPlayerFrame(parentInterface, parentFrame)
 			local buffsToCast = { };
 			local hasBuffs = nil;
 			for __, details in ipairs(module.CTRA_Configuration_Buffs[class]) do
-				if (GetSpellInfo(L["CT_RaidAssist/Spells/" .. details.name]) and (details.gameVersion == nil or details.gameVersion == module:getGameVersion()) and (buffsToCast[details.modifier] == nil)) then
-					buffsToCast[details.modifier] = L["CT_RaidAssist/Spells/" .. details.name];
+				if (GetSpellInfo(details.name) and (details.gameVersion == nil or details.gameVersion == module:getGameVersion()) and (buffsToCast[details.modifier] == nil)) then
+					buffsToCast[details.modifier] = details.name;
 					hasBuffs = true;
 				end
 			end

--- a/CT_RaidAssist/CT_RaidAssist.toc
+++ b/CT_RaidAssist/CT_RaidAssist.toc
@@ -1,5 +1,5 @@
 ## Interface: 80300
-## Version: 8.3.0.1
+## Version: 8.3.0.3
 ## Title: CT_RaidAssist |cFF333333(BFA)
 ## Author: TS & Cide (Original), Dargen (MT Addon), DDC (Redesign)
 ## Notes: Monitor raid HP and click cast buffs, debuff removals, resurrections

--- a/CT_RaidAssist/CT_RaidAssist_ExpansionData.lua
+++ b/CT_RaidAssist/CT_RaidAssist_ExpansionData.lua
@@ -35,29 +35,30 @@ module.CTRA_Configuration_Buffs =
 {
 	["PRIEST"] =
 	{
-		{["name"] = "Power Word: Fortitude", ["modifier"] = "nomod", },
+		{["name"] = "Power Word: Fortitude", ["modifier"] = "nomod", ["id"] = 211681, ["gameVersion"] = CT_GAME_VERSION_RETAIL},
+		{["name"] = "Power Word: Fortitude", ["modifier"] = "nomod", ["id"] = 1243, ["gameVersion"] = CT_GAME_VERSION_CLASSIC},
 	},
 	["MAGE"] =
 	{
-		{["name"] = "Arcane Intellect", ["modifier"] = "nomod", } ,
-		{["name"] = "Arcane Brilliance", ["modifier"] = "mod:shift", ["gameVersion"] = CT_GAME_VERSION_CLASSIC,},
-		{["name"] = "Amplify Magic", ["modifier"] = "mod:ctrl", ["gameVersion"] = CT_GAME_VERSION_CLASSIC,},
-		{["name"] = "Dampen Magic", ["modifier"] = "mod:alt", ["gameVersion"] = CT_GAME_VERSION_CLASSIC,},
+		{["name"] = "Arcane Intellect", ["modifier"] = "nomod", ["id"] = 1459},
+		{["name"] = "Arcane Brilliance", ["modifier"] = "mod:shift", ["id"] = 23028, ["gameVersion"] = CT_GAME_VERSION_CLASSIC},
+		{["name"] = "Amplify Magic", ["modifier"] = "mod:ctrl", ["id"] = 1008, ["gameVersion"] = CT_GAME_VERSION_CLASSI,},
+		{["name"] = "Dampen Magic", ["modifier"] = "mod:alt", ["id"] = 604, ["gameVersion"] = CT_GAME_VERSION_CLASSIC},
 	},
 	["WARRIOR"] =
 	{	
-		{["name"] = "Battle Shout", ["modifier"] = "nomod",},
+		{["name"] = "Battle Shout", ["modifier"] = "nomod", ["id"] = 6673},
 	},
 	["HUNTER"] =
 	{
-		{["name"] = "Trueshot Aura", ["modifier"] = "nomod", ["gameVersion"] = CT_GAME_VERSION_CLASSIC,},
+		{["name"] = "Trueshot Aura", ["modifier"] = "nomod", ["id"] = 19506, ["gameVersion"] = CT_GAME_VERSION_CLASSIC},
 	},
 	["PALADIN"] = 
 	{
-		{["name"] = "Blessing of Kings", ["modifier"] = "nomod", ["gameVersion"] = CT_GAME_VERSION_CLASSIC,},
-		{["name"] = "Blessing of Wisdom", ["modifier"] = "mod:shift", ["gameVersion"] = CT_GAME_VERSION_CLASSIC,},
-		{["name"] = "Blessing of Might", ["modifier"] = "mod:ctrl", ["gameVersion"] = CT_GAME_VERSION_CLASSIC,},
-		{["name"] = "Blessing of Salvation", ["modifier"] = "mod:alt", ["gameVersion"] = CT_GAME_VERSION_CLASSIC,},
+		{["name"] = "Blessing of Kings", ["modifier"] = "nomod", ["id"] = 20217, ["gameVersion"] = CT_GAME_VERSION_CLASSIC},
+		{["name"] = "Blessing of Wisdom", ["modifier"] = "mod:shift", ["id"] = 19742, ["gameVersion"] = CT_GAME_VERSION_CLASSIC},
+		{["name"] = "Blessing of Might", ["modifier"] = "mod:ctrl", ["id"] = 19740, ["gameVersion"] = CT_GAME_VERSION_CLASSIC},
+		{["name"] = "Blessing of Salvation", ["modifier"] = "mod:alt", ["id"] = 1038, ["gameVersion"] = CT_GAME_VERSION_CLASSIC},
 	}
 }
 
@@ -76,39 +77,41 @@ module.CTRA_Configuration_FriendlyRemoves =
 {			
 	["DRUID"] =										
 	{											
-		{["name"] = "Nature's Cure", ["modifier"] = "nomod", ["magic"] = true, ["curse"] = true, ["poison"] = true, ["gameVersion"] = CT_GAME_VERSION_RETAIL},
-		{["name"] = "Remove Corruption", ["modifier"] = "nomod", ["curse"] = true, ["poison"] = true, ["gameVersion"] = CT_GAME_VERSION_RETAIL},
-		{["name"] = "Abolish Poison", ["modifier"] = "nomod", ["poison"] = true, ["gameVersion"] = CT_GAME_VERSION_CLASSIC},
-		{["name"] = "Cure Poison", ["modifier"] = "nomod", ["poison"] = true, ["gameVersion"] = CT_GAME_VERSION_CLASSIC},  	--  the first available 'nomod' on the list has precedence, so at lvl 26 this stops being used
-		{["name"] = "Remove Curse", ["modifier"] = "mod:shift", ["curse"] = true, ["gameVersion"] = CT_GAME_VERSION_CLASSIC},
+		{["name"] = "Nature's Cure", ["modifier"] = "nomod", ["id"] = 88423, ["gameVersion"] = CT_GAME_VERSION_RETAIL},
+		{["name"] = "Remove Corruption", ["modifier"] = "nomod", ["id"] = 2782, ["gameVersion"] = CT_GAME_VERSION_RETAIL},
+		{["name"] = "Abolish Poison", ["modifier"] = "nomod", ["id"] = 2893, ["gameVersion"] = CT_GAME_VERSION_CLASSIC},
+		{["name"] = "Cure Poison", ["modifier"] = "nomod", ["id"] = 8946, ["gameVersion"] = CT_GAME_VERSION_CLASSIC},  	--  the first available 'nomod' on the list has precedence, so at lvl 26 this stops being used
+		{["name"] = "Remove Curse", ["modifier"] = "mod:shift", ["id"] = 2782, ["gameVersion"] = CT_GAME_VERSION_CLASSIC},
 	},
 	["MAGE"] =
 	{
-		{["name"] = "Remove Curse", ["modifier"] = "nomod", ["curse"] = true},
-		{["name"] = "Remove Lesser Curse", ["modifier"] = "nomod", ["curse"] = true},
+		{["name"] = "Remove Curse", ["modifier"] = "nomod", ["id"] = 475, ["gameVersion"] = CT_GAME_VERSION_RETAIL},
+		{["name"] = "Remove Lesser Curse", ["modifier"] = "nomod", ["id"] = 475, ["gameVersion"] = CT_GAME_VERSION_CLASSIC},
 	},
 	["MONK"] =
 	{
-		{["name"] = "Detox", ["modifier"] = "nomod", ["spec"] = 270, ["magic"] = true, ["poison"] = true, ["disease"] = true},
-		{["name"] = "Detox", ["modifier"] = "nomod", ["poison"] = true, ["disease"] = true},	-- this is superceded for mistweavers by the higher one on the list with spec=270
+		{["name"] = "Detox", ["modifier"] = "nomod", ["id"] = 115450, ["spec"] = 270},
+		{["name"] = "Detox", ["modifier"] = "nomod", ["id"] = 218164},	-- this is superceded for mistweavers by the higher one on the list with spec=270
 	},
 	["PALADIN"] =
 	{
-		{["name"] = "Cleanse", ["modifier"] = "nomod", ["magic"] = true, ["poison"] = true, ["disease"] = true},	-- exists (in roughly equivalent forms) in both retail and classic
-		{["name"] = "Cleanse  Toxins", ["modifier"] = "nomod", ["poison"] = true, ["disease"] = true, ["gameVersion"] = CT_GAME_VERSION_RETAIL},	-- used by specs in retail who don't get the full cleanse
-		{["name"] = "Purify", ["modifier"] = "nomod", ["poison"] = true, ["disease"] = true, ["gameVersion"] = CT_GAME_VERSION_CLASSIC},	--at higher levels, replaced by cleanse
+		{["name"] = "Cleanse", ["modifier"] = "nomod", ["id"] = 4987},
+		{["name"] = "Cleanse  Toxins", ["modifier"] = "nomod", ["id"] = 213644, ["gameVersion"] = CT_GAME_VERSION_RETAIL},	-- used by specs in retail who don't get the full cleanse
+		{["name"] = "Purify", ["modifier"] = "nomod", ["id"] = 1152, ["gameVersion"] = CT_GAME_VERSION_CLASSIC},	--at higher levels, replaced by cleanse
 	},
 	["PRIEST"] = 
 	{
-		{["name"] = "Purify", ["modifier"] = "nomod", ["magic"] = true, ["disease"] = true, ["gameVersion"] = CT_GAME_VERSION_RETAIL},
-		{["name"] = "Purify Disease", ["modifier"] = "nomod", ["disease"] = true, ["gameVersion"] = CT_GAME_VERSION_RETAIL},
-		{["name"] = "Cure Disease", ["modifier"] = "mod:shift", ["disease"] = true, ["gameVersion"] = CT_GAME_VERSION_CLASSIC},
-		{["name"] = "Dispel Magic", ["modifier"] = "nomod", ["magic"] = true, ["gameVersion"] = CT_GAME_VERSION_CLASSIC},
+		{["name"] = "Purify", ["modifier"] = "nomod", ["id"] = 527, ["gameVersion"] = CT_GAME_VERSION_RETAIL},
+		{["name"] = "Purify Disease", ["modifier"] = "nomod", ["id"] = 213634, ["gameVersion"] = CT_GAME_VERSION_RETAIL},
+		{["name"] = "Cure Disease", ["modifier"] = "mod:shift", ["id"] = 528, ["gameVersion"] = CT_GAME_VERSION_CLASSIC},
+		{["name"] = "Dispel Magic", ["modifier"] = "nomod", ["id"] = 527, ["gameVersion"] = CT_GAME_VERSION_CLASSIC},
 	},
 	["SHAMAN"] =
 	{
-		{["name"] = "Purify Spirit", ["modifier"] = "nomod", ["magic"] = true, ["curse"] = true},
-		{["name"] = "Cleanse Spirit", ["modifier"] = "nomod", ["curse"] = true},
+		{["name"] = "Purify Spirit", ["modifier"] = "nomod", ["id"] = 77130, ["gameVersion"] = CT_GAME_VERSION_RETAIL},
+		{["name"] = "Cleanse Spirit", ["modifier"] = "nomod", ["id"] = 51886, ["gameVersion"] = CT_GAME_VERSION_RETAIL},
+		{["name"] = "Cure Poison", ["modifier"] = "mod:shift", ["id"] = 526},
+		{["name"] = "Cure Disease", ["modifier"] = "mod:alt", ["id"] = 2870},
 	},
 }
 
@@ -126,31 +129,30 @@ module.CTRA_Configuration_RezAbilities =
 {
 	["DRUID"] =
 	{
-		{["name"] = "Rebirth", ["modifier"] = "nomod", ["combat"] = true},
-		{["name"] = "Revive", ["modifier"] = "nomod", ["nocombat"] = true},
+		{["name"] = "Rebirth", ["modifier"] = "nomod", ["id"] = 20484, ["combat"] = true},
+		{["name"] = "Revive", ["modifier"] = "nomod", ["id"] = 50769, ["nocombat"] = true},
 	},
 	["DEATHKNIGHT"] =
 	{
-		{["name"] = "Raise Ally", ["modifier"] = "nomod", ["combat"] = true, ["nocombat"] = true},
+		{["name"] = "Raise Ally", ["modifier"] = "nomod", ["id"] = 61999, ["combat"] = true, ["nocombat"] = true},
 	},
 	["WARLOCK"] =
 	{
-		{["name"] = "Soulstone", ["modifier"] = "nomod", ["combat"] = true, ["gameVersion"] = CT_GAME_VERSION_RETAIL},	--TO DO: Make a classic version that uses the soulstone sitting in the bags
+		{["name"] = "Soulstone", ["modifier"] = "nomod", ["id"] = 5232, ["combat"] = true, ["gameVersion"] = CT_GAME_VERSION_RETAIL},	--TO DO: Make a classic version that uses the soulstone sitting in the bags
 	},
 	["PALADIN"] =
 	{
-		{["name"] = "Redemption", ["modifier"] = "nomod", ["nocombat"] = true},
+		{["name"] = "Redemption", ["modifier"] = "nomod", ["id"] = 7328, ["nocombat"] = true},
 	},	
 	["PRIEST"] =
 	{
-		{["name"] = "Resurrection", ["modifier"] = "nomod", ["nocombat"] = true},
+		{["name"] = "Resurrection", ["modifier"] = "nomod", ["id"] = 2006, ["nocombat"] = true},
 	},	
 	["SHAMAN"] =
 	{
-		{["name"] = "Ancestral Spirit", ["modifier"] = "nomod", ["nocombat"] = true},
+		{["name"] = "Ancestral Spirit", ["modifier"] = "nomod", ["id"] = 2008, ["nocombat"] = true},
 	},
 }
-
 
 ------------------------------------------------
 -- CTRA_Configuration_BossAuras
@@ -220,7 +222,6 @@ module.CTRA_Configuration_BossAuras =
 	[307399] = 5,		-- Ny'alotha - Maut: Arcane Wounds
 	[314337] = 1,		-- Ny'alotha - Maut: Ancient Curse
 }
-
 
 ------------------------------------------------
 -- CTRA_Configuration_Consumables
@@ -404,3 +405,24 @@ module.CTRA_Configuration_Consumables =
 	[297117] = 168315, -- Famine Evaluator And Snack Table (Int)
 	[297118] = 168315, -- Famine Evaluator And Snack Table (Str)
 } 
+
+
+
+------------------------------------------------
+-- Localization
+
+local function localizeClickCasting(table)
+	local class = select(2, UnitClass("player"));
+	if (table[class]) then
+		for i, details in ipairs(table[class]) do
+			if (C_Spell.DoesSpellExist(details.id) and (details.gameVersion == module:getGameVersion() or not details.gameVersion)) then
+				local spell = Spell:CreateFromSpellID(details.id);
+				spell:ContinueOnSpellLoad(function() details.name = GetSpellInfo(details.id) end);
+			end
+		end
+	end
+end
+
+localizeClickCasting(module.CTRA_Configuration_Buffs);
+localizeClickCasting(module.CTRA_Configuration_FriendlyRemoves);
+localizeClickCasting(module.CTRA_Configuration_RezAbilities);

--- a/CT_RaidAssist/changes.txt
+++ b/CT_RaidAssist/changes.txt
@@ -1,3 +1,6 @@
+CT_RaidAssist (8.3.0.3) 2020-01-18
+- Click-cast functionality extended to all localisations
+
 CT_RaidAssist (8.3.0.1) 2020-01-13
 - New options for blending in class colours to backgrounds and borders
 


### PR DESCRIPTION
8.3.0.3 (20 Jan 20)

- Fixed: Controls to use key-up/down and mouse-up/down with CT_BarMod

- Fixed: Error message in the Warlords of Draenor (Retail) Garrison with CT_MapMod

- Localization: Support for detecting German-language ore nodes with CT_MapMod

- Localization: Support for click-casting in all remaining languages with CT_RaidAssist
