### PR TITLE
8.3.0.10

### DIFF
--- a/CT_BarMod/CT_BarMod.toc
+++ b/CT_BarMod/CT_BarMod.toc
@@ -1,5 +1,5 @@
 ## Interface: 80300
-## Version: 8.3.0.9
+## Version: 8.3.0.10
 ## Title: CT_BarMod |cFF333333(BFA)
 ## Notes: Intuitive yet powerful action bar addon.
 ## DefaultState: Enabled

--- a/CT_BarMod/CT_BarMod_Use.lua
+++ b/CT_BarMod/CT_BarMod_Use.lua
@@ -1887,33 +1887,17 @@ do
 	local isReset = true;
 
 	local function CT_BarMod_ActionButton_UpdateHotkeys(self, ...)
-		if (not defbarShowBindings) then
-			local hotkey = self.HotKey;		-- _G[self:GetName().."HotKey"];
+		if (defbarShowBindings) then
+			local hotkey = self.HotKey;		-- _G[self:GetName().."HotKey"];			
 			if (displayBindings and displayRangeDot) then
 				-- Default behavior of standard UI is to display both.
 				hotkey:SetAlpha(1);
-				return;
-			end
-			local hide;
-			if (not displayBindings) then
-				if (not displayRangeDot) then
-					hide = true;
-				else
-					if (hotkey:GetText() ~= rangeIndicator) then
-						hide = true;
-					end
-				end
-			else
-				if (not displayRangeDot) then
-					if (hotkey:GetText() == rangeIndicator) then
-						hide = true;
-					end
-				end
-			end
-			if (hide) then
-				hotkey:SetAlpha(0);
-			else
+			elseif (displayRangeDot and hotkey:GetText() == rangeIndicator) then
 				hotkey:SetAlpha(1);
+			elseif (displayBindings and hotkey:GetText() ~= rangeIndicator) then
+				hotkey:SetAlpha(1);
+			else
+				hotkey:SetAlpha(0);
 			end
 		end
 	end

--- a/CT_BarMod/changes.txt
+++ b/CT_BarMod/changes.txt
@@ -1,3 +1,6 @@
+CT_BarMod (8.3.0.10) 2020-06-08
+- Fixed the "hide range dot" and "hide keybindings" options on non-CT bars
+
 CT_BarMod (8.3.0.9) 2020-05-30
 - Range indications update more frequently, but are also more efficient than before
 - Further reductions in CPU usage via event-handling instead of hooksecurefunc for non-CT bars

--- a/CT_UnitFrames/CT_PartyFrame.lua
+++ b/CT_UnitFrames/CT_PartyFrame.lua
@@ -48,27 +48,28 @@ local function CT_PartyFrame_AnchorSideText_Single(id)
 end
 
 local function CT_PartyFrame_TextStatusBar_UpdateTextString(bar)
-	if (CT_UnitFrameOptions) then
-
-		-- compatibility with WoW Classic
-		local barTextString = bar.TextString or bar.ctTextString;
-		if (not barTextString) then
-			local intermediateFrame = CreateFrame("Frame", nil, bar);
-			intermediateFrame:SetFrameLevel(5);
-			intermediateFrame:SetAllPoints();
-			barTextString = intermediateFrame:CreateFontString(nil, "ARTWORK", "GameTooltipTextSmall");
-			barTextString:SetPoint("CENTER", bar);
-			barTextString.ctControlled = "Party";
-			bar.ctTextString = barTextString;
-		end
-
-		-- font
-		if (barTextString.ctSize ~= (CT_UnitFramesOptions.partyTextSize or 3)) then
-			barTextString.ctSize = CT_UnitFramesOptions.partyTextSize or 3
-			barTextString:SetFont("Fonts\\FRIZQT__.TTF", barTextString.ctSize + 7, "OUTLINE");
-			bar.textRight:SetFont("Fonts\\FRIZQT__.TTF", barTextString.ctSize + 7);
-		end
+	if (CT_UnitFramesOptions) then
 		
+		bar.ctUsePartyFontSize = true;
+		
+		textString = bar.textRight;
+		if (textString.ctSize ~= (CT_UnitFramesOptions.partyTextSize or 3) + 6) then
+			textString.ctSize = (CT_UnitFramesOptions.partyTextSize or 3) + 6;
+			textString.ctControlled = "ChangeSize"
+		end
+		if (module:getGameVersion() == 1) then
+			if (textString.ctControlled ~= "Retail" and CT_UnitFramesOptions.makeFontLikeRetail) then
+				textString:SetFont("Fonts\\FRIZQT__.TTF", textString.ctSize, "OUTLINE");
+				textString.ctControlled = "Retail";
+			elseif (textString.ctControlled ~= "Classic" and not CT_UnitFramesOptions.makeFontLikeRetail) then
+				textString:SetFont("Fonts\\ARIALN.TTF", textString.ctSize + 3, "OUTLINE");
+				textString.ctControlled = "Classic";	
+			end
+		elseif (textString.ctControlled == "ChangeSize") then
+			textString.ctControlled = nil;
+			textString:SetFont("Fonts\\FRIZQT__.TTF", textString.ctSize, "OUTLINE");
+		end
+
 		-- apply changes for the health and mana bars
 		if (bar.type == "health") then	
 			module:UpdateStatusBarTextString(bar, CT_UnitFramesOptions.styles[2][1])

--- a/CT_UnitFrames/CT_UnitFrameOptions.lua
+++ b/CT_UnitFrames/CT_UnitFrameOptions.lua
@@ -516,14 +516,14 @@ function CT_UnitFrameOptions_SetOptionsFrame(name)
 	if (module.currBoxFrame) then
 		module.currBoxFrame:Hide();
 	end
-	if (_G["CT_Library"]:getGameVersion() == CT_GAME_VERSION_RETAIL) then
+	if (module:getGameVersion() >= 2) then
 		-- Enable all page buttons
 		CT_UnitFramesOptionsFramePlayerOptions:Enable();
 		CT_UnitFramesOptionsFramePartyOptions:Enable();
 		CT_UnitFramesOptionsFrameTargetOptions:Enable();
 		CT_UnitFramesOptionsFrameAssistOptions:Enable();
 		CT_UnitFramesOptionsFrameFocusOptions:Enable();
-	elseif (_G["CT_Library"]:getGameVersion() == CT_GAME_VERSION_CLASSIC) then
+	else
 		CT_UnitFramesOptionsFramePlayerOptions:Enable();
 		CT_UnitFramesOptionsFramePartyOptions:Enable();
 		CT_UnitFramesOptionsFrameTargetOptions:Enable();
@@ -559,8 +559,10 @@ function CT_UnitFramesOptions_OneColorHealth_CB_OnClick(self, checked)
 	module:ShowPlayerFrameBarText();
 	module:ShowPartyFrameBarText();
 	module:ShowTargetFrameBarText();
-	module:ShowAssistFrameBarText();
-	module:ShowFocusFrameBarText();
+	if (module:getGameVersion() >= 2) then
+		module:ShowAssistFrameBarText();
+		module:ShowFocusFrameBarText();
+	end
 end
 
 function CT_UnitFramesOptions_LargeBreakUp_CB_OnClick(self, checked)
@@ -568,8 +570,10 @@ function CT_UnitFramesOptions_LargeBreakUp_CB_OnClick(self, checked)
 	module:ShowPlayerFrameBarText();
 	module:ShowPartyFrameBarText();
 	module:ShowTargetFrameBarText();
-	module:ShowAssistFrameBarText();
-	module:ShowFocusFrameBarText();
+	if (module:getGameVersion() >= 2) then
+		module:ShowAssistFrameBarText();
+		module:ShowFocusFrameBarText();
+	end
 end
 
 function CT_UnitFramesOptions_LargeAbbreviate_CB_OnClick(self, checked)
@@ -577,8 +581,10 @@ function CT_UnitFramesOptions_LargeAbbreviate_CB_OnClick(self, checked)
 	module:ShowPlayerFrameBarText();
 	module:ShowPartyFrameBarText();
 	module:ShowTargetFrameBarText();
-	module:ShowAssistFrameBarText();
-	module:ShowFocusFrameBarText();
+	if (module:getGameVersion() >= 2) then
+		module:ShowAssistFrameBarText();
+		module:ShowFocusFrameBarText();
+	end
 end
 
 function CT_UnitFramesOptions_MakeFontLikeRetail_CB_OnClick(self, checked)
@@ -586,8 +592,10 @@ function CT_UnitFramesOptions_MakeFontLikeRetail_CB_OnClick(self, checked)
 	module:ShowPlayerFrameBarText();
 	module:ShowPartyFrameBarText();
 	module:ShowTargetFrameBarText();
-	module:ShowAssistFrameBarText();
-	module:ShowFocusFrameBarText();
+	if (module:getGameVersion() >= 2) then
+		module:ShowAssistFrameBarText();
+		module:ShowFocusFrameBarText();
+	end
 end
 
 --------------------------------------------

--- a/CT_UnitFrames/CT_UnitFrameOptions.xml
+++ b/CT_UnitFrames/CT_UnitFrameOptions.xml
@@ -716,7 +716,7 @@ C:\Projects\WoW\Bin\Interface\FrameXML\UI.xsd">
 							</OnShow>
 							<OnValueChanged>
 								CT_UnitFramesOptions.partyTextSize = self:GetValue();
-								_G[self:GetName().."Text"]:SetText(CT_UFO_PARTYTEXTSIZE .. " = "..self:GetValue()+7);
+								_G[self:GetName().."Text"]:SetText(CT_UFO_PARTYTEXTSIZE .. " = "..self:GetValue()+6);
 								CT_UnitFramesOptions_Radio_Update();
 							</OnValueChanged>
 						</Scripts>

--- a/CT_UnitFrames/CT_UnitFrames.lua
+++ b/CT_UnitFrames/CT_UnitFrames.lua
@@ -97,16 +97,25 @@ function module:UpdateStatusBarTextString(textStatusBar, settings, lockShow)
 	end
 
 	-- STEP 2:
+	if (textStatusBar.ctUsePartyFontSize) then
+		if (textString.ctSize ~= (CT_UnitFramesOptions.partyTextSize or 3) + 6) then
+			textString.ctSize = (CT_UnitFramesOptions.partyTextSize or 3) + 6
+			textString.ctControlled = "ChangeSize"
+		end
+	else
+		textString.ctSize = 10
+	end
 	if (module:getGameVersion() == 1) then
-		if ((textString.ctControlled == "Classic" or textString.ctControlled == nil) and CT_UnitFramesOptions.makeFontLikeRetail) then
-			-- set or change it to retail font, but do it just once
-			textString:SetFont("Fonts\\FRIZQT__.TTF", 10, "OUTLINE");
+		if (textString.ctControlled ~= "Retail" and CT_UnitFramesOptions.makeFontLikeRetail) then
+			textString:SetFont("Fonts\\FRIZQT__.TTF", textString.ctSize, "OUTLINE");
 			textString.ctControlled = "Retail";
-		elseif ((textString.ctControlled == "Retail" or textString.ctControlled == nil) and not CT_UnitFramesOptions.makeFontLikeRetail) then
-			-- set or change it to classic font, but do it just once
-			textString:SetFont("Fonts\\ARIALN.TTF", 14, "OUTLINE");
+		elseif (textString.ctControlled ~= "Classic" and not CT_UnitFramesOptions.makeFontLikeRetail) then
+			textString:SetFont("Fonts\\ARIALN.TTF", textStatusBar.ctUsePartyFontSize and textString.ctSize + 3 or textString.ctSize + 4, "OUTLINE");
 			textString.ctControlled = "Classic";	
 		end
+	elseif (textString.ctControlled == "ChangeSize") then
+		textString.ctControlled = nil;
+		textString:SetFont("Fonts\\FRIZQT__.TTF", textString.ctSize, "OUTLINE");
 	end
 	
 	-- STEP 3:

--- a/CT_UnitFrames/CT_UnitFrames.toc
+++ b/CT_UnitFrames/CT_UnitFrames.toc
@@ -1,5 +1,5 @@
 ## Interface: 80300
-## Version: 8.3.0.9
+## Version: 8.3.0.10
 ## Title: CT_UnitFrames |cFF333333(BFA)
 ## Notes: Changes display of hp/mana values and adds a percentage.
 ## DefaultState: Enabled

--- a/CT_UnitFrames/changes.txt
+++ b/CT_UnitFrames/changes.txt
@@ -1,3 +1,6 @@
+CT_UnitFrames (8.3.0.10) 2020-06-09
+- Fix to health/mana values on party-member bars after big changes in 8.3.0.9
+
 CT_UnitFrames (8.3.0.9) 2020-06-03
 - Significant performance improvements using RegisterUnitEvent() and other techniques
 - Class-colours on party members updated after /reload or disconnect

--- a/CT_Viewport/CT_Viewport.lua
+++ b/CT_Viewport/CT_Viewport.lua
@@ -505,6 +505,10 @@ function CT_ViewportFrame_OnLoad(self)
 	hooksecurefunc(WorldFrame, "ClearAllPoints", CT_Viewport_ApplySavedViewport);
 	hooksecurefunc(WorldFrame, "SetAllPoints", CT_Viewport_ApplySavedViewport);
 	hooksecurefunc(WorldFrame, "SetPoint", CT_Viewport_ApplySavedViewport);
+	
+	-- Beginning in Battle for Azeroth, some raid encounters have cinematics during combat.  Examples: Jaina freezing the sea, or N'Zoth special area on mythic mode
+	CinematicFrame:SetScript("OnShow", nil);
+	CinematicFrame:SetScript("OnHide", nil);
 
 	-- The game reloads the UI when switching between different aspect ratios.
 	-- The game does not reload the UI when switching between resolutions with the same aspect ratio.

--- a/CT_Viewport/CT_Viewport.toc
+++ b/CT_Viewport/CT_Viewport.toc
@@ -1,5 +1,5 @@
 ## Interface: 80300
-## Version: 8.2.0.4
+## Version: 8.3.0.10
 ## Title: CT_Viewport |cFF333333(BFA)
 ## Notes: Allows you to change the rendered world's size.
 ## DefaultState: Enabled

--- a/CT_Viewport/changes.txt
+++ b/CT_Viewport/changes.txt
@@ -1,3 +1,6 @@
+CT_Viewport (8.3.0.10) 2020-06-10
+- Maintains a custom viewport during mid-encounter cut scenes (e.g. Jaina or Mythic N'Zoth)
+
 CT_Viewport (8.2.0.4) 2019-06-30
 - Added safeguards to prevent the game from becoming unusable
 


### PR DESCRIPTION
8.3.0.10 (10 Jun 20)
- Fixed: Text on party-member health/mana bars with CT_UnitFrames
- Fixed: Option to hide the "range dot" on non-CT bars with CT_BarMod
- Fixed: Maintain a custom screen size during mid-encounter cut scenes with CT_Viewport