### PR TITLE
10.0.2.3

### DIFF
--- a/CT_BarMod/CT_BarMod-Classic.toc
+++ b/CT_BarMod/CT_BarMod-Classic.toc
@@ -1,5 +1,5 @@
 ## Interface: 11403
-## Version: 10.0.2.2
+## Version: 10.0.2.3
 ## Title: CT_BarMod
 ## Notes: Intuitive yet powerful action bar addon.
 ## DefaultState: Enabled

--- a/CT_BarMod/CT_BarMod-Wrath.toc
+++ b/CT_BarMod/CT_BarMod-Wrath.toc
@@ -1,5 +1,5 @@
 ## Interface: 30400
-## Version: 10.0.2.2
+## Version: 10.0.2.3
 ## Title: CT_BarMod
 ## Notes: Intuitive yet powerful action bar addon.
 ## DefaultState: Enabled

--- a/CT_BarMod/CT_BarMod.toc
+++ b/CT_BarMod/CT_BarMod.toc
@@ -1,5 +1,5 @@
 ## Interface: 100002
-## Version: 10.0.2.2
+## Version: 10.0.2.3
 ## Title: CT_BarMod
 ## Notes: Intuitive yet powerful action bar addon.
 ## DefaultState: Enabled

--- a/CT_BarMod/CT_BarMod_SpellFlyout.lua
+++ b/CT_BarMod/CT_BarMod_SpellFlyout.lua
@@ -91,10 +91,10 @@ spellFlyout:SetScript("OnEvent", function(self, event, ...)
 			i = i+1;
 			button = _G["CT_BarMod_SpellFlyoutButton"..i];
 		end
-	elseif (event == "PET_STABLE_UPDATE" or event == "PET_STABLE_SHOW") then
-		self:Hide();
-	elseif (event == "ACTIONBAR_PAGE_CHANGED") then
-		self:Hide();
+	elseif (event == "PET_STABLE_UPDATE" or event == "PET_STABLE_SHOW") and not InCombatLockdown() then		-- InCombatLockdown() required because this is insecure
+		self:Hide();  -- TODO: Find a way to securely do this during combat
+	--elseif (event == "ACTIONBAR_PAGE_CHANGED") then
+		--self:Hide();  -- Replaced with OnShow SecureHandler that creates a SecureStateDriver with "[nobar:##] hide;"
 	end
 end)
 
@@ -296,3 +296,7 @@ function module.updateFlyout(self, isButtonDownOverride)
 		flyoutArrowTexture:SetPoint("TOP", self, "TOP", 0, arrowDistance);
 	end
 end
+
+-- Hide the spell flyout when the action bar changes; secure alternative to SpellFlyout's event handler
+SecureHandlerWrapScript(spellFlyout, "OnShow", spellFlyout, [=[	RegisterAttributeDriver(self, "state-visibility", "[nobar:" .. GetActionBarPage() .."]hide") ]=], nil)
+SecureHandlerWrapScript(spellFlyout, "OnHide", spellFlyout, [=[ RegisterAttributeDriver(self, "state-visibility", "") ]=], nil)

--- a/CT_BarMod/changes.txt
+++ b/CT_BarMod/changes.txt
@@ -1,3 +1,6 @@
+CT_BarMod (10.0.2.3) 2022-12-10
+- Securely closing spell flyout to avoid errors in Dragonflight
+
 CT_BarMod (10.0.2.2) 2022-12-04
 - Custom spell flyout button to mitigate taint in Dragonflight
 - Updates to align with CT_BottomBar

--- a/CT_Library/CT_Library-Classic.toc
+++ b/CT_Library/CT_Library-Classic.toc
@@ -1,5 +1,5 @@
 ## Interface: 11403
-## Version: 10.0.2.2
+## Version: 10.0.2.3
 ## Title: CT_Library |cFFCC6600CTMod|r
 ## Notes: Library features for CTMod. 
 ## DefaultState: Enabled

--- a/CT_Library/CT_Library-Wrath.toc
+++ b/CT_Library/CT_Library-Wrath.toc
@@ -1,5 +1,5 @@
 ## Interface: 30400
-## Version: 10.0.2.2
+## Version: 10.0.2.3
 ## Title: CT_Library |cFFCC6600CTMod|r
 ## Notes: Library features for CTMod. 
 ## DefaultState: Enabled

--- a/CT_Library/CT_Library.toc
+++ b/CT_Library/CT_Library.toc
@@ -1,5 +1,5 @@
 ## Interface: 100002
-## Version: 10.0.2.2
+## Version: 10.0.2.3
 ## Title: CT_Library |cFFCC6600CTMod|r
 ## Notes: Library features for CTMod. 
 ## DefaultState: Enabled

--- a/CT_Library/Libs/TaintLess.xml
+++ b/CT_Library/Libs/TaintLess.xml
@@ -1,6 +1,6 @@
 <Ui><Script><![CDATA[--[[
 
-TaintLess [22-09-15]
+TaintLess [22-11-27]
 https://www.townlong-yak.com/addons/taintless
 
 All rights reserved.
@@ -9,14 +9,28 @@ Permission is hereby granted to distribute unmodified copies of this file.
 ]]
 
 local function purgeKey(t, k)
+	local logLevel, c = GetCVar("taintLog"), -42
+	if (tonumber(logLevel) or 0) > 1 then
+		if CVarCallbackRegistry then
+			CVarCallbackRegistry:UnregisterEvent("CVAR_UPDATE")
+		end
+		SetCVar("taintLog", "1")
+	else
+		logLevel = nil
+	end
 	t[k] = nil
-	local c = 42
 	repeat
 		if t[c] == nil then
 			t[c] = nil
 		end
-		c = c + 1
+		c = c - 1
 	until issecurevariable(t, k)
+	if logLevel then
+		SetCVar("taintLog", logLevel)
+		if CVarCallbackRegistry then
+			CVarCallbackRegistry:RegisterEvent("CVAR_UPDATE")
+		end
+	end
 end
 
 -- https://www.townlong-yak.com/addons/taintless/fixes/RefreshOverread
@@ -57,4 +71,60 @@ if (tonumber(IOFRAME_SELECTION_PATCH_VERSION) or 0) < 3 then
 	end
 end
 
+-- https://www.townlong-yak.com/addons/taintless/fixes/EditModeOpenDrop
+if EditModeManagerFrame and FriendsFrameStatusDropDown and (tonumber(EDITMAN_OPENDROP_PATCH_VERSION) or 0) < 1 then
+	EDITMAN_OPENDROP_PATCH_VERSION = 1
+	hooksecurefunc(EditModeManagerFrame, "GetAttribute", function(_, attr)
+		if attr ~= "UIPanelLayout-checkFit" or EDITMAN_OPENDROP_PATCH_VERSION ~= 1
+		   or (issecurevariable(DropDownList1, "maxWidth") and issecurevariable("UIDROPDOWNMENU_MENU_LEVEL")) then
+		elseif InCombatLockdown() and FriendsFrameStatusDropDown:IsProtected() then
+		elseif FriendsFrameStatusDropDown:IsVisible() then
+			FriendsFrameStatusDropDown:Hide()
+			FriendsFrameStatusDropDown:Show()
+		else
+			local op = FriendsFrameStatusDropDown:GetParent()
+			FriendsFrameStatusDropDown:SetParent(nil)
+			if not FriendsFrameStatusDropDown:IsShown() then
+				FriendsFrameStatusDropDown:Show()
+				FriendsFrameStatusDropDown:Hide()
+			end
+			FriendsFrameStatusDropDown:SetParent(op)
+		end
+	end)
+end
+
+-- https://www.townlong-yak.com/addons/taintless/fixes/ObjectiveTrackerUpdate
+if ObjectiveTrackerFrame and (tonumber(OBJTRACK_DELAYUPDATE_PATCH_VERSION) or 0) < 1 then
+	OBJTRACK_DELAYUPDATE_PATCH_VERSION = 1
+	local counter, didDelayUpdate, delayFrameCount = (CreateFrame("Frame", nil, ObjectiveTrackerFrame))
+	counter:Hide()
+	counter:SetScript("OnUpdate", function()
+		if OBJTRACK_DELAYUPDATE_PATCH_VERSION == 1 then
+			delayFrameCount = delayFrameCount + 1
+		else
+			counter:Hide()
+		end
+	end)
+	hooksecurefunc("ObjectiveTracker_Update", function()
+		if OBJTRACK_DELAYUPDATE_PATCH_VERSION == 1 and didDelayUpdate then
+			didDelayUpdate = nil
+			purgeKey(ObjectiveTrackerFrame, "isUpdating")
+		end
+	end)
+	hooksecurefunc(ObjectiveTrackerFrame.HeaderMenu.Title, "ClearAllPoints", function()
+		if OBJTRACK_DELAYUPDATE_PATCH_VERSION == 1 and not ObjectiveTrackerFrame.isUpdating then
+			if issecurevariable(ObjectiveTrackerFrame, "isOnLeftSideOfScreen") then
+				if delayFrameCount then
+					delayFrameCount = nil
+					counter:Hide()
+				end
+			elseif (delayFrameCount or 0) < 4 then
+				ObjectiveTrackerFrame.isUpdating, didDelayUpdate, delayFrameCount = 86, 1, delayFrameCount or 0
+				counter:Show()
+			else
+				counter:Hide()
+			end
+		end
+	end)
+end
 ]]></Script></Ui>

--- a/CT_Library/changes.txt
+++ b/CT_Library/changes.txt
@@ -1,3 +1,6 @@
+CT_Library (10.0.2.3) 2022-12-10
+- Library update
+
 CT_Library (10.0.2.2) 2022-12-01
 - Labels no longer automatically localize using global variable names
 

--- a/CT_PartyBuffs/CT_PartyBuffs-Classic.toc
+++ b/CT_PartyBuffs/CT_PartyBuffs-Classic.toc
@@ -1,5 +1,5 @@
 ## Interface: 11403
-## Version: 10.0.2.1
+## Version: 10.0.2.3
 ## Title: CT_PartyBuffs
 ## Notes: Shows buffs at party member frames.
 ## DefaultState: Enabled

--- a/CT_PartyBuffs/CT_PartyBuffs-Wrath.toc
+++ b/CT_PartyBuffs/CT_PartyBuffs-Wrath.toc
@@ -1,5 +1,5 @@
 ## Interface: 30400
-## Version: 10.0.2.1
+## Version: 10.0.2.3
 ## Title: CT_PartyBuffs
 ## Notes: Shows buffs at party member frames.
 ## DefaultState: Enabled

--- a/CT_PartyBuffs/CT_PartyBuffs.lua
+++ b/CT_PartyBuffs/CT_PartyBuffs.lua
@@ -293,13 +293,13 @@ do
 		frame:Hide()
 		frame:SetScript("OnShow", partyMemberFrame_OnShow)
 		frame:SetScript("OnHide", partyMemberFrame_OnHide)		
-		RegisterAttributeDriver(frame, "state-visibility", "[group:raid]hide;[@party"..id..",exists]show;hide")	-- useful starting in WoW 10.x because it is now parented by PartyFrame that never disappears
+		RegisterAttributeDriver(frame, "state-visibility", "[group:raid]hide;[@arena1,exists]hide;[@party"..id..",exists]show;hide")	-- useful starting in WoW 10.x because it is now parented by PartyFrame that never disappears
 		if CompactPartyFrame then
 			CompactPartyFrame:HookScript("OnShow", function()
 				module:afterCombat(RegisterAttributeDriver, frame, "state-visibility", "hide")
 			end)
 			CompactPartyFrame:HookScript("OnHide", function()
-				module:afterCombat(RegisterAttributeDriver, frame, "state-visibility", "[group:raid]hide;[@party"..id..",exists]show;hide")
+				module:afterCombat(RegisterAttributeDriver, frame, "state-visibility", "[group:raid]hide;[@arena1,exists]hide;[@party"..id..",exists]show;hide")
 			end)
 		end
 	end

--- a/CT_PartyBuffs/CT_PartyBuffs.toc
+++ b/CT_PartyBuffs/CT_PartyBuffs.toc
@@ -1,5 +1,5 @@
 ## Interface: 100002
-## Version: 10.0.2.1
+## Version: 10.0.2.3
 ## Title: CT_PartyBuffs
 ## Notes: Shows buffs at party member frames.
 ## DefaultState: Enabled

--- a/CT_PartyBuffs/changes.txt
+++ b/CT_PartyBuffs/changes.txt
@@ -1,3 +1,6 @@
+CT_PartyBuffs (10.0.2.3) 2022-12-17
+- Buffs hidden during arena matches
+
 CT_PartyBuffs (10.0.2.1) 2022-11-20
 - Hiding buffs when the party shrinks in size
 

--- a/CT_UnitFrames/CT_TargetFrame.lua
+++ b/CT_UnitFrames/CT_TargetFrame.lua
@@ -15,22 +15,17 @@ local module = select(2, ...);
 local healthBar = TargetFrameHealthBar or TargetFrame.TargetFrameContent.TargetFrameContentMain.HealthBar
 local manaBar = TargetFrameManaBar or TargetFrame.TargetFrameContent.TargetFrameContentMain.ManaBar
 
-local inworld;
 function CT_TargetFrameOnEvent(self, event, arg1, ...)
 
-	if ( event == "PLAYER_ENTERING_WORLD" ) then
-		if (inworld == nil) then
-			inworld = 1;
-			if (UnitFrame_UpdateThreatIndicator) then
-				hooksecurefunc("UnitFrame_UpdateThreatIndicator", CT_TargetFrame_UpdateThreatIndicator);
-			end
-			CT_TargetFrame_SetClassPosition(true);
-
-			if ( GetCVarBool("predictedPower") ) then
-				local statusbar = TargetFrameManaBar;
-				statusbar:SetScript("OnUpdate", UnitFrameManaBar_OnUpdate);
-				UnitFrameManaBar_UnregisterDefaultEvents(statusbar);
-			end
+	if ( event == "PLAYER_LOGIN" ) then
+		if (UnitFrame_UpdateThreatIndicator) then
+			hooksecurefunc("UnitFrame_UpdateThreatIndicator", CT_TargetFrame_UpdateThreatIndicator)
+		end
+		CT_TargetFrame_SetClassPosition(true)
+		if ( GetCVarBool("predictedPower") ) then
+			local statusbar = TargetFrameManaBar
+			statusbar:SetScript("OnUpdate", UnitFrameManaBar_OnUpdate)
+			UnitFrameManaBar_UnregisterDefaultEvents(statusbar)
 		end
 	end
 end
@@ -140,29 +135,34 @@ function CT_TargetFrame_UpdateThreatIndicator(indicator, numericIndicator, unit)
 end
 
 function CT_TargetFrame_SetClassPosition(center)
-	local frame = CT_TargetFrameClassFrame;
-	frame:ClearAllPoints();
+	local frame = CT_TargetFrameClassFrame
+	frame:ClearAllPoints()
 
-	local buffsOnTop = TARGET_FRAME_BUFFS_ON_TOP;
+	local buffsOnTop = TargetFrame.buffsOnTop
 	if (center or buffsOnTop) then
 		-- Center the class over the unit name.
 		if (buffsOnTop) then
 			-- Center class below the unit frame
-			local xoff;
+			local xoff
 			if (TargetFrameToT and TargetFrameToT:IsShown()) then
-				xoff = -13;
+				xoff = -13
 			else
-				xoff = 0;
+				xoff = 0
 			end
-			frame:SetPoint("TOP", TargetFrameTextureFrameName, "BOTTOM", xoff, -31);
+			frame:SetPoint("TOP", TargetFrameTextureFrameName or TargetFrame.TargetFrameContent.TargetFrameContentMain.Name, "BOTTOM", xoff, TargetFrame.TargetFrameContent and -35 or -31);
 		else
-			frame:SetPoint("BOTTOM", TargetFrameTextureFrameName, "TOP", 0, 5);
+			if TargetFrame.TargetFrameContent then
+				frame:SetPoint("BOTTOM", TargetFrame.TargetFrameContent.TargetFrameContentMain.Name, "TOP", 0, 2)
+				frame:SetPoint("RIGHT", TargetFrame.TargetFrameContent.TargetFrameContentContextual.LeaderIcon, "LEFT")
+			else
+				frame:SetPoint("BOTTOM", TargetFrameTextureFrameName, "TOP", 0, 4)
+			end
 		end
 		frame:SetWidth(100);
 		CT_TargetFrameClassFrameText:SetWidth(96);
 	else
 		-- Leave room on the left to display threat indicator.
-		frame:SetPoint("BOTTOMLEFT", TargetFrameTextureFrameName, "TOPLEFT", 35, 5);
+		frame:SetPoint("BOTTOMLEFT", TargetFrameTextureFrameName or TargetFrame.TargetFrameContent.TargetFrameContentMain.Name, "TOPLEFT", 35, 5);
 		frame:SetWidth(86);
 		CT_TargetFrameClassFrameText:SetWidth(82);
 	end

--- a/CT_UnitFrames/CT_TargetFrame.xml
+++ b/CT_UnitFrames/CT_TargetFrame.xml
@@ -27,7 +27,7 @@
 		<Frames>
 			<Frame name="$parentClassFrame" hidden="true">
 				<Size>
-					<AbsDimension x="100" y="25"/>
+					<AbsDimension x="96" y="24"/>
 				</Size>
 
 				<Anchors>
@@ -51,23 +51,24 @@
 				</Layers>
 				<Scripts>
 					<OnLoad>
-						Mixin(self, BackdropTemplateMixin or {});
+						Mixin(self, BackdropTemplateMixin or {})
 						self:SetBackdrop({
 							bgFile = "Interface\\Tooltips\\UI-Tooltip-Background",
 							edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
 							tile = true,
 							tileSize = 16,
-							edgeSize = 16,
-							insets = { left = 5, right = 5, top = 5, bottom = 5 },
-						});
-						self:SetBackdropColor(0, 0, 1, 0.5);
-						self:RegisterUnitEvent("UNIT_FACTION", "target");
-						<!-- (Removed since WoW 5.3.0) self:RegisterEvent("UNIT_DYNAMIC_FLAGS"); -->
-						self:RegisterEvent("PLAYER_TARGET_CHANGED");
-						self:RegisterEvent("GROUP_ROSTER_UPDATE");
+							edgeSize = 12,
+							insets = { left = 3, right = 3, top = 3, bottom = 3 },
+						})
+						self:SetBackdropColor(0, 0, 1, 0.5)
+						self:SetBackdropBorderColor(0.8, 0.8, 0.8, 0.8)
+						self:RegisterUnitEvent("UNIT_FACTION", "target")
+						<!-- (Removed since WoW 5.3.0) self:RegisterEvent("UNIT_DYNAMIC_FLAGS") -->
+						self:RegisterEvent("PLAYER_TARGET_CHANGED")
+						self:RegisterEvent("GROUP_ROSTER_UPDATE")
 					</OnLoad>
 					<OnEvent>
-						CT_SetTargetClass();
+						CT_SetTargetClass()
 					</OnEvent>
 				</Scripts>
 			</Frame>
@@ -75,7 +76,7 @@
 		<Scripts>
 			<OnLoad>
 				self:SetParent(TargetFrameTextureFrame or TargetFrame.TargetFrameContent.TargetFrameContentMain)	-- prior/after WoW 10.x
-				self:RegisterEvent("PLAYER_ENTERING_WORLD");
+				self:RegisterEvent("PLAYER_LOGIN");
 			</OnLoad>
 			<OnEvent>
 				CT_TargetFrameOnEvent(self, event, ...);

--- a/CT_UnitFrames/CT_UnitFrames-Classic.toc
+++ b/CT_UnitFrames/CT_UnitFrames-Classic.toc
@@ -1,5 +1,5 @@
 ## Interface: 11403
-## Version: 10.0.0.4
+## Version: 10.0.2.3
 ## Title: CT_UnitFrames
 ## Notes: Changes display of hp/mana values and adds a percentage.
 ## DefaultState: Enabled

--- a/CT_UnitFrames/CT_UnitFrames-Wrath.toc
+++ b/CT_UnitFrames/CT_UnitFrames-Wrath.toc
@@ -1,5 +1,5 @@
 ## Interface: 30400
-## Version: 10.0.0.4
+## Version: 10.0.2.3
 ## Title: CT_UnitFrames
 ## Notes: Changes display of hp/mana values and adds a percentage.
 ## DefaultState: Enabled

--- a/CT_UnitFrames/CT_UnitFrames.toc
+++ b/CT_UnitFrames/CT_UnitFrames.toc
@@ -1,5 +1,5 @@
 ## Interface: 100002
-## Version: 10.0.0.4
+## Version: 10.0.2.3
 ## Title: CT_UnitFrames
 ## Notes: Changes display of hp/mana values and adds a percentage.
 ## DefaultState: Enabled

--- a/CT_UnitFrames/changes.txt
+++ b/CT_UnitFrames/changes.txt
@@ -1,3 +1,6 @@
+CT_UnitFrames (10.0.2.3) 2022-12-17
+- Updating the target class frame for Dragonflight
+
 CT_UnitFrames (10.0.0.4) 2022-11-12
 - Update for Dragonflight 10.0.2 (build 46619 on the beta)
 


### PR DESCRIPTION
10.0.2.3 (2022-12-17)
- Fewer errors in Dragonflight (including community workarounds via the "Taintless" addon library)
- Target class frame in Dragonflight (including a slightly modernized appearance)
- Hiding party-frame buff icons during arena matches (tentative fix)