### PR TITLE
Update CT_MapMod_ExpansionData.lua

### DIFF
--- a/CT_MapMod/CT_MapMod_ExpansionData.lua
+++ b/CT_MapMod/CT_MapMod_ExpansionData.lua
@@ -488,7 +488,8 @@ module.gatheringSkills =
 	[265835] = "Herb",
 	[309780] = "Herb",	-- Shadowlands
 	[366252] = "Herb",	-- Dragonflight
-
+	[441327] = "Herb",	-- The War Within
+	
 	-- Mining
 	   [186] = "Ore",
 	  [2575] = "Ore",	-- Classic Apprentice
@@ -512,6 +513,7 @@ module.gatheringSkills =
 	[265854] = "Ore",	-- Zandalari
 	[309835] = "Ore",	-- Shadowlands
 	[366260] = "Ore",	-- Dragonflight
+	[423353] = "Ore",	-- The War Within
 }
 
 


### PR DESCRIPTION
Added SpellIDs for Ore and Herb for TWW, but for me, no Ore is shown on map after gathering.
Seems to be something still missing.